### PR TITLE
Add in ApplyBCPatch macro system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Created by https://www.gitignore.io
 
+/test/*
+/examples/*
+
 ### Fortran ###
 # Compiled Object files
 *.slo

--- a/pfsimulator/parflow_lib/bc_dirichlet.h
+++ b/pfsimulator/parflow_lib/bc_dirichlet.h
@@ -1,0 +1,16 @@
+#ifndef _BC_DIRICHLET_H
+#define _BC_DIRICHLET_H
+
+#define Do_AddDirichletBC_Pressure(i, j, k, is, ival, ipatch,           \
+                                   bc_struct, bc_patch_values, body)    \
+  ForBCStructNumPatches(ipatch, bc_struct)                              \
+  {                                                                     \
+    bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);       \
+    {                                                                   \
+      body;                                                             \
+    }                                                                   \
+  }                                                                     \
+
+
+
+#endif // _BC_DIRICHLET_H

--- a/pfsimulator/parflow_lib/bc_face.h
+++ b/pfsimulator/parflow_lib/bc_face.h
@@ -88,7 +88,10 @@
   {                                                                 \
     bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);   \
     {                                                               \
-      body;                                                         \
+      switch(BCStructBCType(bc_struct, ipatch))                     \
+      {                                                             \
+        body;                                                       \
+      }                                                             \
     }                                                               \
   }
 

--- a/pfsimulator/parflow_lib/bc_face.h
+++ b/pfsimulator/parflow_lib/bc_face.h
@@ -1,0 +1,104 @@
+#ifndef _BC_FACE_H
+#define _BC_FACE_H
+
+/*********************************************
+ *
+ * Utility header file for constructing boundary condition face physics selection.
+ * For use in conjunction with BCStructLoopX.
+ *
+ *********************************************/
+
+
+
+/*********************************************
+ *
+ * Safe to call macros for defining BC Patch Face Physics
+ *
+ *********************************************/
+
+#define Left GrGeomOctreeFaceL
+#define Right GrGeomOctreeFaceR
+#define Down GrGeomOctreeFaceD
+#define Up GrGeomOctreeFaceU
+#define Back GrGeomOctreeFaceB
+#define Front GrGeomOctreeFaceF
+#define AllBCTypes default
+#define FACE(a,b) XCASE(a,b)
+#define PROLOGUE(x) x
+#define EPILOGUE(x) x
+#define NO_PROLOGUE PROLOGUE({})
+#define NO_EPILOGUE EPILOGUE({})
+
+/* Apply physics for a boundary condition */
+#define ApplyBCPatch(_case, ...)                \
+  case _case:                                   \
+  {                                             \
+    EXPAND_FACE_PHYSICS(__VA_ARGS__);           \
+    break;                                      \
+  }
+
+/* NOTE: This will be removed once additional OverlandFlow BC conditions are added */
+#define ApplyBCPatchSubtypes(_case, _subcase, equations)  \
+  case _case:                                             \
+  {                                                       \
+    switch ((_subcase))                                   \
+    {                                                     \
+      equations;                                          \
+    }                                                     \
+  }
+
+/* To be called from GrGeomOctreeFaceLoopX */
+#define OctreeFacePhysics(key, ...)              \
+  XSWITCH(key, __VA_ARGS__)
+
+/*********************************************
+ *
+ * Do not call any of the below macros directly!
+ *
+ *********************************************/
+
+/* Case statement with body */
+#define WITH_BODY(_case, body)                  \
+  case _case:                                   \
+  {                                             \
+    body;                                       \
+    break;                                      \
+  }
+
+/* Case statement for fallthrough */
+#define ONLY_CASE(_case)                        \
+  case _case:
+
+/* Variadic macros to determine what type of case to build */
+#define CASE_BODY_SELECTION(arg1, arg2, arg3, ...) arg3
+#define XCASE(...)                              \
+  CASE_BODY_SELECTION(__VA_ARGS__, WITH_BODY, ONLY_CASE)(__VA_ARGS__)
+
+#define XSWITCH(key, ...)                       \
+  switch (key)                                  \
+  {                                                       \
+    EXPAND_FACES(COUNT_VARARGS(__VA_ARGS__))(__VA_ARGS__) \
+  }
+
+// NOTE: This macro will break if too many arguments are passed in
+#define EVAL_COUNT_VARARGS(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+#define COUNT_VARARGS(...) \
+  EVAL_COUNT_VARARGS("not_evaluated", ##__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+/* Macro expansion indirection to get us the right EXPAND_FACES_N macro */
+#define EXPAND_INDIRECTION(n) EXPAND_FACES_ ## n
+#define EXPAND_FACES(n) EXPAND_INDIRECTION(n)
+
+/* This is a bit silly, might be a proper preprocessor way to generate these */
+#define EXPAND_FACES_0(...) {};
+#define EXPAND_FACES_1(a, ...) a
+#define EXPAND_FACES_2(a, ...) a EXPAND_FACES_1(__VA_ARGS__)
+#define EXPAND_FACES_3(a, ...) a EXPAND_FACES_2(__VA_ARGS__)
+#define EXPAND_FACES_4(a, ...) a EXPAND_FACES_3(__VA_ARGS__)
+#define EXPAND_FACES_5(a, ...) a EXPAND_FACES_4(__VA_ARGS__)
+#define EXPAND_FACES_6(a, ...) a EXPAND_FACES_5(__VA_ARGS__)
+
+#define EXPAND_FACE_PHYSICS(prologue, epilogue, ...)  \
+  BCStructPatchLoopX(i, j, k, ival, bc_struct, ipatch, is, prologue, epilogue, __VA_ARGS__);
+
+#endif // _BC_FACE_H

--- a/pfsimulator/parflow_lib/bc_face.h
+++ b/pfsimulator/parflow_lib/bc_face.h
@@ -60,6 +60,18 @@
 #define OctreeFacePhysics(key, ...)              \
   XSWITCH(key, __VA_ARGS__)
 
+/* Used in RichardsJacobianEval and NlFunctionEval to add
+ *    Boundary Condition patch value contributions */
+#define Do_BCContrib(i, j, k, ival, bc_struct, ipatch, is,          \
+                              bc_patch_values, body)                \
+  ForBCStructNumPatches(ipatch, bc_struct)                          \
+  {                                                                 \
+    bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);   \
+    {                                                               \
+      body;                                                         \
+    }                                                               \
+  }
+
 /*********************************************
  *
  * Do not call any of the below macros directly!

--- a/pfsimulator/parflow_lib/bc_face.h
+++ b/pfsimulator/parflow_lib/bc_face.h
@@ -138,7 +138,7 @@
 #if 0
 
 #define ApplyBCPatchExample                     \
-  Do_ApplyDirichlet_Example(i, j, k, ival, bc_struct, ipatch, is, bc_patch_values, \
+  Do_ApplyBCPatch_Example(i, j, k, ival, bc_struct, ipatch, is, bc_patch_values, \
   {                                                                     \
     ApplyBCPatch(DirichletBC,                                           \
                  PROLOGUE({                                             \

--- a/pfsimulator/parflow_lib/bc_face.h
+++ b/pfsimulator/parflow_lib/bc_face.h
@@ -28,6 +28,7 @@
 #define EPILOGUE(x) x
 #define NO_PROLOGUE PROLOGUE({})
 #define NO_EPILOGUE EPILOGUE({})
+#define PRECONDITION(x) x
 
 /* Apply physics for a boundary condition */
 #define ApplyBCPatch(_case, ...)                \
@@ -45,6 +46,14 @@
     {                                                     \
       equations;                                          \
     }                                                     \
+  }
+
+#define ApplyBCPatch_WithPrecondition(_case, precondition, ...) \
+  case _case:                                                   \
+  {                                                             \
+    precondition;                                               \
+    EXPAND_FACE_PHYSICS(__VA_ARGS__);                           \
+    break;                                                      \
   }
 
 /* To be called from GrGeomOctreeFaceLoopX */

--- a/pfsimulator/parflow_lib/bc_richards.h
+++ b/pfsimulator/parflow_lib/bc_richards.h
@@ -4,13 +4,25 @@
 #define Do_Richards_SymmContrib(i, j, k, ival, bc_struct, ipatch, is, body) \
   ForBCStructNumPatches(ipatch, bc_struct)                              \
   {                                                                     \
-    body;                                                               \
+    switch(BCStructBCType(bc_struct, ipatch))                           \
+    {                                                                   \
+      body;                                                             \
+    }                                                                   \
   }
 
 #define Do_Richards_BuildJCMatrix(i, j, k, ival, bc_struct, ipatch, is, body) \
   ForBCStructNumPatches(ipatch, bc_struct)                              \
   {                                                                     \
-    body;                                                               \
+    switch(BCStructBCType(bc_struct, ipatch))                           \
+    {                                                                   \
+      body;                                                             \
+    }                                                                   \
+  }
+
+#define IfSurfaceNode(k1, k, body)              \
+  if (((k) >= 0) && ((k1) == (k)))              \
+  {                                             \
+    body;                                       \
   }
 
 #endif // _BC_RICHARDS_H

--- a/pfsimulator/parflow_lib/bc_richards.h
+++ b/pfsimulator/parflow_lib/bc_richards.h
@@ -1,0 +1,26 @@
+#ifndef _BC_RICHARDS_H
+#define _BC_RICHARDS_H
+
+#define Do_Richards_SymmContrib(i, j, k, ival, bc_struct, ipatch, is, body) \
+  ForBCStructNumPatches(ipatch, bc_struct)                              \
+  {                                                                     \
+    body;                                                               \
+  }
+
+#define Do_Richards_BCContrib(i, j, k, ival, bc_struct, ipatch, is,     \
+                              bc_patch_values, body)                    \
+  ForBCStructNumPatches(ipatch, bc_struct)                              \
+  {                                                                     \
+    bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);       \
+    {                                                                   \
+      body;                                                             \
+    }                                                                   \
+  }
+
+#define Do_Richards_BuildJCMatrix(i, j, k, ival, bc_struct, ipatch, is, body) \
+  ForBCStructNumPatches(ipatch, bc_struct)                              \
+  {                                                                     \
+    body;                                                               \
+  }
+
+#endif // _BC_RICHARDS_H

--- a/pfsimulator/parflow_lib/bc_richards.h
+++ b/pfsimulator/parflow_lib/bc_richards.h
@@ -7,16 +7,6 @@
     body;                                                               \
   }
 
-#define Do_Richards_BCContrib(i, j, k, ival, bc_struct, ipatch, is,     \
-                              bc_patch_values, body)                    \
-  ForBCStructNumPatches(ipatch, bc_struct)                              \
-  {                                                                     \
-    bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);       \
-    {                                                                   \
-      body;                                                             \
-    }                                                                   \
-  }
-
 #define Do_Richards_BuildJCMatrix(i, j, k, ival, bc_struct, ipatch, is, body) \
   ForBCStructNumPatches(ipatch, bc_struct)                              \
   {                                                                     \

--- a/pfsimulator/parflow_lib/grgeom_octree.h
+++ b/pfsimulator/parflow_lib/grgeom_octree.h
@@ -1149,6 +1149,31 @@ typedef struct grgeom_octree {
     }) \
   }
 
+
+/*--------------------------------------------------------------------------
+ * Experimental Octree Face looping macro:
+ *   For use in conjunction with GrGeomPatchLoopX
+ *--------------------------------------------------------------------------*/
+#define GrGeomOctreeFaceLoopX(i, j, k, node, octree, level_of_interest, \
+                              ix, iy, iz, nx, ny, nz,                   \
+                              prologue, epilogue, ...)                  \
+  {                                                                     \
+    int PV_f;                                                           \
+                                                                        \
+    GrGeomOctreeInsideNodeLoop(i, j, k, node, octree, level_of_interest, \
+                               ix, iy, iz, nx, ny, nz,                  \
+                               TRUE,                                    \
+    {                                                                   \
+      for (PV_f = 0; PV_f < GrGeomOctreeNumFaces; PV_f++)               \
+        if (GrGeomOctreeHasFace(node, PV_f))                            \
+        {                                                               \
+          prologue;                                                     \
+          OctreeFacePhysics(PV_f, __VA_ARGS__);                         \
+          epilogue;                                                     \
+        }                                                               \
+    });                                                                 \
+  }
+
 /*==========================================================================
  *==========================================================================*/
 

--- a/pfsimulator/parflow_lib/grgeometry.h
+++ b/pfsimulator/parflow_lib/grgeometry.h
@@ -235,6 +235,31 @@ typedef struct {
 
 
 /*--------------------------------------------------------------------------
+ * Experimental GrGeomSolid looping macro:
+ *   Macro for looping over the faces of a solid patch.
+ *   For use in conjunction with BCStructPatchLoopX
+ *--------------------------------------------------------------------------*/
+
+#define GrGeomPatchLoopX(i, j, k, grgeom, patch_num,            \
+                        r, ix, iy, iz, nx, ny, nz,              \
+                        prologue, epilogue, ...)                \
+  {                                                             \
+    GrGeomOctree  *PV_node;                                     \
+    double PV_ref = pow(2.0, r);                                \
+                                                                \
+                                                                \
+    i = GrGeomSolidOctreeIX(grgeom) * (int)PV_ref;              \
+    j = GrGeomSolidOctreeIY(grgeom) * (int)PV_ref;              \
+    k = GrGeomSolidOctreeIZ(grgeom) * (int)PV_ref;              \
+    GrGeomOctreeFaceLoopX(i, j, k, fdir, PV_node,               \
+                         GrGeomSolidPatch(grgeom, patch_num),   \
+                         GrGeomSolidOctreeBGLevel(grgeom) + r,  \
+                          ix, iy, iz, nx, ny, nz,               \
+                          prologue, epilogue, __VA_ARGS__);     \
+  }
+
+
+/*--------------------------------------------------------------------------
  * GrGeomSolid looping macro:
  * Macro for looping over the inside of a solid as a set of boxes.
  * This will pick both active and inactive cells along the boundary but

--- a/pfsimulator/parflow_lib/nl_function_eval.c
+++ b/pfsimulator/parflow_lib/nl_function_eval.c
@@ -526,24 +526,12 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
                        ip = SubvectorEltIndex(p_sub, i, j, k);
                      }),
                    NO_EPILOGUE,
-                   FACE(Left, {
-                       pp[ip - 1] = value;
-                     }),
-                   FACE(Right, {
-                       pp[ip + 1] = value;
-                     }),
-                   FACE(Down, {
-                       pp[ip - sy_p] = value;
-                     }),
-                   FACE(Up, {
-                       pp[ip + sy_p] = value;
-                     }),
-                   FACE(Back, {
-                       pp[ip - sz_p] = value;
-                     }),
-                   FACE(Front, {
-                       pp[ip + sz_p] = value;
-                     })
+                   FACE(Left,  { pp[ip - 1] = value; }),
+                   FACE(Right, { pp[ip + 1] = value; }),
+                   FACE(Down,  { pp[ip - sy_p] = value; }),
+                   FACE(Up,    { pp[ip + sy_p] = value; }),
+                   FACE(Back,  { pp[ip - sz_p] = value; }),
+                   FACE(Front, { pp[ip + sz_p] = value; })
                    );
 
     }); // End Do_AddDirichletBC_Pressure
@@ -1052,1015 +1040,608 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
                                (permzp[ip] / viscosity)
                                * 2.0 * diff;
                      })
-                   ); // End DirichletBC
+        ); // End DirichletBC
 
-ApplyBCPatch(FluxBC,
-             PROLOGUE({
-                 ip = SubvectorEltIndex(p_sub, i, j, k);
-                 io = SubvectorEltIndex(x_ssl_sub, i, j, grid2_iz);
-                 x_dir_g = 0.0;
-                 y_dir_g = 0.0;
-                 z_dir_g = 1.0;
-                 del_x_slope = 1.0;
-                 del_y_slope = 1.0;
-               }),
-             EPILOGUE({
-                 fp[ip] -= dt * dir * u_old;
-                 u_new = u_new * bc_patch_values[ival];
-                 fp[ip] += dt * dir * u_new;
-               }),
-             FACE(Left, {
-                 dir = -1;
-                 diff = pp[ip - 1] - pp[ip];
-                 u_old = z_mult_dat[ip] * ffx * del_y_slope
-                         * PMean(pp[ip - 1], pp[ip],
-                                 permxp[ip - 1], permxp[ip])
-                         * (diff / dx * del_x_slope)
-                         * RPMean(pp[ip - 1], pp[ip],
-                                  rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
-                         / viscosity;
+      ApplyBCPatch(FluxBC,
+                   PROLOGUE({
+                       ip = SubvectorEltIndex(p_sub, i, j, k);
+                       io = SubvectorEltIndex(x_ssl_sub, i, j, grid2_iz);
+                       x_dir_g = 0.0;
+                       y_dir_g = 0.0;
+                       z_dir_g = 1.0;
+                       del_x_slope = 1.0;
+                       del_y_slope = 1.0;
+                     }),
+                   EPILOGUE({
+                       fp[ip] -= dt * dir * u_old;
+                       u_new = u_new * bc_patch_values[ival];
+                       fp[ip] += dt * dir * u_new;
+                     }),
+                   FACE(Left, {
+                       dir = -1;
+                       diff = pp[ip - 1] - pp[ip];
+                       u_old = z_mult_dat[ip] * ffx * del_y_slope
+                               * PMean(pp[ip - 1], pp[ip],
+                                       permxp[ip - 1], permxp[ip])
+                               * (diff / dx * del_x_slope)
+                               * RPMean(pp[ip - 1], pp[ip],
+                                        rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
+                               / viscosity;
 
-                 u_old += z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip - 1], pp[ip],
-                                  permxp[ip - 1], permxp[ip])
-                          * (-x_dir_g)
-                          * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
-                                   rpp[ip] * dp[ip])
-                          / viscosity;
+                       u_old += z_mult_dat[ip] * ffx * del_y_slope
+                                * PMean(pp[ip - 1], pp[ip],
+                                        permxp[ip - 1], permxp[ip])
+                                * (-x_dir_g)
+                                * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
+                                         rpp[ip] * dp[ip])
+                                / viscosity;
 
-                 u_new = z_mult_dat[ip] * ffx;
-               }),
-             FACE(Right, {
-                 dir = 1;
-                 diff = pp[ip] - pp[ip + 1];
-                 u_old = z_mult_dat[ip] * ffx * del_y_slope
-                         * PMean(pp[ip], pp[ip + 1],
-                                 permxp[ip], permxp[ip + 1])
-                         * (diff / dx * del_x_slope)
-                         * RPMean(pp[ip], pp[ip + 1],
-                                  rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
-                         / viscosity;
+                       u_new = z_mult_dat[ip] * ffx;
+                     }),
+                   FACE(Right, {
+                       dir = 1;
+                       diff = pp[ip] - pp[ip + 1];
+                       u_old = z_mult_dat[ip] * ffx * del_y_slope
+                               * PMean(pp[ip], pp[ip + 1],
+                                       permxp[ip], permxp[ip + 1])
+                               * (diff / dx * del_x_slope)
+                               * RPMean(pp[ip], pp[ip + 1],
+                                        rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
+                               / viscosity;
 
-                 u_old += z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip], pp[ip + 1],
-                                  permxp[ip], permxp[ip + 1])
-                          * (-x_dir_g)
-                          * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
-                                   rpp[ip + 1] * dp[ip + 1])
-                          / viscosity;
+                       u_old += z_mult_dat[ip] * ffx * del_y_slope
+                                * PMean(pp[ip], pp[ip + 1],
+                                        permxp[ip], permxp[ip + 1])
+                                * (-x_dir_g)
+                                * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
+                                         rpp[ip + 1] * dp[ip + 1])
+                                / viscosity;
 
-                 u_new = z_mult_dat[ip] * ffx;
-               }),
-             FACE(Down, {
-                 dir = -1;
-                 diff = pp[ip - sy_p] - pp[ip];
-                 u_old = z_mult_dat[ip] * ffy * del_x_slope
-                         * PMean(pp[ip - sy_p], pp[ip],
-                                 permyp[ip - sy_p], permyp[ip])
-                         * (diff / dy)
-                         * RPMean(pp[ip - sy_p], pp[ip],
-                                  rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
-                         / viscosity;
+                       u_new = z_mult_dat[ip] * ffx;
+                     }),
+                   FACE(Down, {
+                       dir = -1;
+                       diff = pp[ip - sy_p] - pp[ip];
+                       u_old = z_mult_dat[ip] * ffy * del_x_slope
+                               * PMean(pp[ip - sy_p], pp[ip],
+                                       permyp[ip - sy_p], permyp[ip])
+                               * (diff / dy)
+                               * RPMean(pp[ip - sy_p], pp[ip],
+                                        rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
+                               / viscosity;
 
-                 u_old += z_mult_dat[ip] * ffy * del_x_slope *
-                          PMean(pp[ip], pp[ip - sy_p], permyp[ip],
-                                permyp[ip - sy_p])
-                          * (-y_dir_g)
-                          * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
-                                   rpp[ip - sy_p] * dp[ip - sy_p])
-                          / viscosity;
+                       u_old += z_mult_dat[ip] * ffy * del_x_slope *
+                                PMean(pp[ip], pp[ip - sy_p], permyp[ip],
+                                      permyp[ip - sy_p])
+                                * (-y_dir_g)
+                                * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
+                                         rpp[ip - sy_p] * dp[ip - sy_p])
+                                / viscosity;
 
-                 u_new = z_mult_dat[ip] * ffy * del_x_slope;
-               }),
-             FACE(Up, {
-                 dir = 1;
-                 diff = pp[ip] - pp[ip + sy_p];
-                 u_old = z_mult_dat[ip] * ffy * del_x_slope
-                         * PMean(pp[ip], pp[ip + sy_p],
-                                 permyp[ip], permyp[ip + sy_p])
-                         * (diff / dy)
-                         * RPMean(pp[ip], pp[ip + sy_p],
-                                  rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
-                         / viscosity;
+                       u_new = z_mult_dat[ip] * ffy * del_x_slope;
+                     }),
+                   FACE(Up, {
+                       dir = 1;
+                       diff = pp[ip] - pp[ip + sy_p];
+                       u_old = z_mult_dat[ip] * ffy * del_x_slope
+                               * PMean(pp[ip], pp[ip + sy_p],
+                                       permyp[ip], permyp[ip + sy_p])
+                               * (diff / dy)
+                               * RPMean(pp[ip], pp[ip + sy_p],
+                                        rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
+                               / viscosity;
 
-                 u_old += z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
-                                  permyp[ip + sy_p])
-                          * (-y_dir_g)
-                          * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
-                                   rpp[ip + sy_p] * dp[ip + sy_p])
-                          / viscosity;
+                       u_old += z_mult_dat[ip] * ffy * del_x_slope
+                                * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
+                                        permyp[ip + sy_p])
+                                * (-y_dir_g)
+                                * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
+                                         rpp[ip + sy_p] * dp[ip + sy_p])
+                                / viscosity;
 
-                 u_new = z_mult_dat[ip] * ffy * del_x_slope;
-               }),
-             FACE(Back, {
-                 dir = -1;
-                 sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
+                       u_new = z_mult_dat[ip] * ffy * del_x_slope;
+                     }),
+                   FACE(Back, {
+                       dir = -1;
+                       sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
 
-                 lower_cond = (pp[ip - sz_p] / sep)
-                              - (z_mult_dat[ip - sz_p]
-                                 / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
-                              * dp[ip - sz_p] * gravity
-                              * z_dir_g;
+                       lower_cond = (pp[ip - sz_p] / sep)
+                                    - (z_mult_dat[ip - sz_p]
+                                       / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                                    * dp[ip - sz_p] * gravity
+                                    * z_dir_g;
 
-                 upper_cond = (pp[ip] / sep)
-                              + (z_mult_dat[ip]
-                                 / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
-                              * dp[ip] * gravity
-                              * z_dir_g;
+                       upper_cond = (pp[ip] / sep)
+                                    + (z_mult_dat[ip]
+                                       / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                                    * dp[ip] * gravity
+                                    * z_dir_g;
 
-                 diff = lower_cond - upper_cond;
-                 u_old = ffz * del_x_slope * del_y_slope
-                         * PMeanDZ(permzp[ip - sz_p], permzp[ip],
-                                   z_mult_dat[ip - sz_p], z_mult_dat[ip])
-                         * diff
-                         * RPMean(lower_cond, upper_cond,
-                                  rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
-                         / viscosity;
+                       diff = lower_cond - upper_cond;
+                       u_old = ffz * del_x_slope * del_y_slope
+                               * PMeanDZ(permzp[ip - sz_p], permzp[ip],
+                                         z_mult_dat[ip - sz_p], z_mult_dat[ip])
+                               * diff
+                               * RPMean(lower_cond, upper_cond,
+                                        rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
+                               / viscosity;
 
-                 u_new = ffz * del_x_slope * del_y_slope;
-               }),
-             FACE(Front, {
-                 dir = 1;
-                 sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
+                       u_new = ffz * del_x_slope * del_y_slope;
+                     }),
+                   FACE(Front, {
+                       dir = 1;
+                       sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
 
-                 lower_cond = (pp[ip] / sep)
-                              - (z_mult_dat[ip]
-                                 / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
-                              * dp[ip] * gravity
-                              * z_dir_g;
+                       lower_cond = (pp[ip] / sep)
+                                    - (z_mult_dat[ip]
+                                       / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                                    * dp[ip] * gravity
+                                    * z_dir_g;
 
-                 upper_cond = (pp[ip + sz_p] / sep)
-                              + (z_mult_dat[ip + sz_p]
-                                 / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
-                              * dp[ip + sz_p] * gravity
-                              * z_dir_g;
+                       upper_cond = (pp[ip + sz_p] / sep)
+                                    + (z_mult_dat[ip + sz_p]
+                                       / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                                    * dp[ip + sz_p] * gravity
+                                    * z_dir_g;
 
-                 diff = lower_cond - upper_cond;
-                 u_old = ffz * del_x_slope * del_y_slope
-                         * PMeanDZ(permzp[ip], permzp[ip + sz_p],
-                                   z_mult_dat[ip], z_mult_dat[ip + sz_p])
-                         * diff
-                         * RPMean(lower_cond, upper_cond,
-                                  rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
-                         / viscosity;
+                       diff = lower_cond - upper_cond;
+                       u_old = ffz * del_x_slope * del_y_slope
+                               * PMeanDZ(permzp[ip], permzp[ip + sz_p],
+                                         z_mult_dat[ip], z_mult_dat[ip + sz_p])
+                               * diff
+                               * RPMean(lower_cond, upper_cond,
+                                        rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
+                               / viscosity;
 
-                 u_new = ffz * del_x_slope * del_y_slope;
-               })
-             ); // End FluxBC
+                       u_new = ffz * del_x_slope * del_y_slope;
+                     })
+        ); // End FluxBC
 
-// TODO: Need to add kenamtic version
-// TODO: Need to address BCStructPatchLoopOvrlnd in between BCStructPatchLoops
-// TODO: Need to add Overlandspinup version
- ApplyBCPatch_WithPrecondition(OverlandDiffusiveBC,
- {
-   // Equivalent to diffusive == 0
-   PRECONDITION({
-       double *dummy1, *dummy2, *dummy3, *dummy4;
-       PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
-                          (grid, is, bc_struct, ipatch, problem_data, pressure,
-                           ke_, kw_, kn_, ks_,
-                           dummy1, dummy2, dummy3, dummy4,
-                           qx_, qy_, CALCFCN));
-     }),
-     PROLOGUE({
-         ip = SubvectorEltIndex(p_sub, i, j, k);
-         io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
-         x_dir_g = 0.0;
-         y_dir_g = 0.0;
-         z_dir_g = 1.0;
-         del_x_slope = 1.0;
-         del_y_slope = 1.0;
-       }),
-     EPILOGUE({
-         fp[ip] -= dt * dir * u_old;
-         u_new = u_new * bc_patch_values[ival];
-         fp[ip] += dt * dir * u_new;
-       }),
-     FACE(Left, {
-         dir = -1;
-         diff = pp[ip - 1] - pp[ip];
-         u_old = z_mult_dat[ip] * ffx * del_y_slope
-                 * PMean(pp[ip - 1], pp[ip],
-                         permxp[ip - 1], permxp[ip])
-                 * (diff / dx)
-                 * RPMean(pp[ip - 1], pp[ip],
-                          rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
-                 / viscosity;
-
-         u_old += z_mult_dat[ip] * ffx * del_y_slope
-                  * PMean(pp[ip - 1], pp[ip],
-                          permxp[ip - 1], permxp[ip])
-                  * (-x_dir_g)
-                  * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
-                           rpp[ip] * dp[ip])
-                  / viscosity;
-
-         u_new = z_mult_dat[ip] * ffx * del_y_slope;
-       }),
-     FACE(Right, {
-         dir = 1;
-         diff = pp[ip] - pp[ip + 1];
-         u_old = z_mult_dat[ip] * ffx * del_y_slope
-                 * PMean(pp[ip], pp[ip + 1],
-                         permxp[ip], permxp[ip + 1])
-                 * (diff / dx)
-                 * RPMean(pp[ip], pp[ip + 1],
-                          rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
-                 / viscosity;
-
-         u_old += z_mult_dat[ip] * ffx * del_y_slope
-                  * PMean(pp[ip], pp[ip + 1],
-                          permxp[ip], permxp[ip + 1])
-                  * (-x_dir_g)
-                  * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
-                           rpp[ip + 1] * dp[ip + 1])
-                  / viscosity;
-
-         u_new = z_mult_dat[ip] * ffx * del_y_slope;
-       }),
-     FACE(Down, {
-         dir = -1;
-         diff = pp[ip - sy_p] - pp[ip];
-         u_old = z_mult_dat[ip] * ffy * del_x_slope
-                 * PMean(pp[ip - sy_p], pp[ip],
-                         permyp[ip - sy_p], permyp[ip])
-                 * (diff / dy)
-                 * RPMean(pp[ip - sy_p], pp[ip],
-                          rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
-                 / viscosity;
-
-         u_old += z_mult_dat[ip] * ffy * del_x_slope *
-                  PMean(pp[ip], pp[ip - sy_p], permyp[ip],
-                        permyp[ip - sy_p])
-                  * (-y_dir_g)
-                  * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
-                           rpp[ip - sy_p] * dp[ip - sy_p])
-                  / viscosity;
-
-         u_new = z_mult_dat[ip] * ffy * del_x_slope;
-       }),
-     FACE(Up, {
-         dir = 1;
-         diff = pp[ip] - pp[ip + sy_p];
-         u_old = z_mult_dat[ip] * ffy * del_x_slope
-                 * PMean(pp[ip], pp[ip + sy_p],
-                         permyp[ip], permyp[ip + sy_p])
-                 * (diff / dy)
-                 * RPMean(pp[ip], pp[ip + sy_p],
-                          rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
-                 / viscosity;
-
-         u_old += z_mult_dat[ip] * ffy * del_x_slope
-                  * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
-                          permyp[ip + sy_p])
-                  * (-y_dir_g)
-                  * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
-                           rpp[ip + sy_p] * dp[ip + sy_p])
-                  / viscosity;
-
-         u_new = z_mult_dat[ip] * ffy * del_x_slope;
-       }),
-     FACE(Back, {
-         dir = -1;
-         sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
-         //  sep = dz*z_mult_dat[ip];  //RMM
-
-         lower_cond = (pp[ip - sz_p] / sep)
-                      - (z_mult_dat[ip - sz_p]
-                         / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
-                      * dp[ip - sz_p] * gravity
-                      * z_dir_g;
-         upper_cond = (pp[ip] / sep)
-                      + (z_mult_dat[ip]
-                         / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
-                      * dp[ip] * gravity
-                      * z_dir_g;
-
-         diff = lower_cond - upper_cond;
-         u_old = ffz * del_x_slope * del_y_slope
-                 * PMeanDZ(permzp[ip - sz_p], permzp[ip],
-                           z_mult_dat[ip - sz_p], z_mult_dat[ip])
-                 * diff
-                 * RPMean(lower_cond, upper_cond,
-                          rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
-                 / viscosity;
-
-         u_new = ffz * del_x_slope * del_y_slope;
-       }),
-     FACE(Front, {
-         dir = 1;
-         sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
-
-         lower_cond = (pp[ip] / sep)
-                      - (z_mult_dat[ip]
-                         / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
-                      * dp[ip] * gravity
-                      * z_dir_g;
-         upper_cond = (pp[ip + sz_p] / sep)
-                      + (z_mult_dat[ip + sz_p]
-                         / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
-                      * dp[ip + sz_p] * gravity
-                      * z_dir_g;
-         diff = lower_cond - upper_cond;
-         u_old = ffz * del_x_slope * del_y_slope
-                 * PMeanDZ(permzp[ip], permzp[ip + sz_p],
-                           z_mult_dat[ip], z_mult_dat[ip + sz_p])
-                 * diff
-                 * RPMean(lower_cond, upper_cond,
-                          rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
-                 / viscosity;
-
-         u_new = ffz * del_x_slope * del_y_slope;
-       })
-     }); // End OverlandDiffusiveBC
-
-
-    });
-
-    for (ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
-    {
-      bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);
-
-      switch (BCStructBCType(bc_struct, ipatch))
+      // TODO: This and OverlandKinematicBC repeat the entire thing except for PFModuleInvoke
+      // Can we consolidate somehow?
+      ApplyBCPatch_WithPrecondition(OverlandDiffusiveBC,
       {
-        case DirichletBC:
-        {
-          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            ip = SubvectorEltIndex(p_sub, i, j, k);
-            io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
-
-            value = bc_patch_values[ival];
-            x_dir_g = 0.0;
-            y_dir_g = 0.0;
-            z_dir_g = 1.0;
-
-            del_x_slope = (1.0 / cos(atan(x_ssl_dat[io])));
-            del_y_slope = (1.0 / cos(atan(y_ssl_dat[io])));
-
-            del_x_slope = 1.0;
-            del_y_slope = 1.0;
-
-
-            /* Don't currently do upstream weighting on boundaries */
-
-            if (fdir[0])
-            {
-              switch (fdir[0])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - 1] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip - 1], pp[ip], permxp[ip - 1], permxp[ip])
-                          * (diff / dx * del_x_slope)
-                          * RPMean(pp[ip - 1], pp[ip],
-                                   rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope *
-                           PMean(pp[ip - 1], pp[ip],
-                                 permxp[ip - 1], permxp[ip])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
-                                    rpp[ip] * dp[ip])
-                           / viscosity;
-
-                  diff = value - pp[ip];
-                  u_new = RPMean(value, pp[ip],
-                                 rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip]);
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + 1];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip], pp[ip + 1], permxp[ip], permxp[ip + 1])
-                          * (diff / dx * del_x_slope)
-                          * RPMean(pp[ip], pp[ip + 1],
-                                   rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope
-                           * PMean(pp[ip], pp[ip + 1],
-                                   permxp[ip], permxp[ip + 1])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
-                                    rpp[ip + 1] * dp[ip + 1])
-                           / viscosity;
-
-                  diff = pp[ip] - value;
-                  u_new = RPMean(pp[ip], value,
-                                 rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1]);
-                  break;
-              }
-              u_new = u_new * z_mult_dat[ip] * ffx * del_y_slope
-                      * (permxp[ip] / viscosity)
-                      * 2.0 * (diff / dx);
-            }
-            else if (fdir[1])
-            {
-              switch (fdir[1])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - sy_p] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip - sy_p], pp[ip],
-                                  permyp[ip - sy_p], permyp[ip])
-                          * (diff / dy * del_y_slope)
-                          * RPMean(pp[ip - sy_p], pp[ip],
-                                   rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope *
-                           PMean(pp[ip], pp[ip - sy_p], permyp[ip],
-                                 permyp[ip - sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip - sy_p] * dp[ip - sy_p])
-                           / viscosity;
-
-
-                  diff = value - pp[ip];
-                  u_new = RPMean(value, pp[ip],
-                                 rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip]);
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + sy_p];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip], pp[ip + sy_p],
-                                  permyp[ip], permyp[ip + sy_p])
-                          * (diff / dy * del_y_slope)
-                          * RPMean(pp[ip], pp[ip + sy_p],
-                                   rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope
-                           * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
-                                   permyp[ip + sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip + sy_p] * dp[ip + sy_p])
-                           / viscosity;
-
-
-                  diff = pp[ip] - value;
-                  u_new = RPMean(pp[ip], value,
-                                 rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p]);
-                  break;
-              }
-              u_new = u_new * z_mult_dat[ip] * ffy * del_x_slope * (permyp[ip] / viscosity)
-                      * 2.0 * (diff / dy);
-            }
-            else if (fdir[2])
-            {
-              switch (fdir[2])
-              {
-                case -1:
-                  {
-                    dir = -1;
-                    sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
-
-                    lower_cond = pp[ip - sz_p] / sep
-                                 - (z_mult_dat[ip - sz_p] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip - sz_p] * gravity *
-                                 z_dir_g;
-
-                    upper_cond = pp[ip] / sep + (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip] * gravity *
-                                 z_dir_g;
-
-                    diff = (lower_cond - upper_cond);
-
-                    u_old = ffz * del_x_slope * del_y_slope
-                            * PMeanDZ(permzp[ip - sz_p], permzp[ip],
-                                      z_mult_dat[ip - sz_p], z_mult_dat[ip])
-                            * diff
-                            * RPMean(lower_cond, upper_cond,
-                                     rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
-                            / viscosity;
-
-                    sep = dz * z_mult_dat[ip] / 2.0;
-
-                    lower_cond = value / sep - 0.25 * dp[ip] * gravity;
-                    upper_cond = pp[ip] / sep + 0.25 * dp[ip] * gravity;
-                    diff = (lower_cond - upper_cond);
-                    u_new = RPMean(lower_cond, upper_cond,
-                                   rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip]);
-                    break;
-                  }         /* End case -1 */
-
-                case  1:
-                  {
-                    dir = 1;
-
-                    /* Calculate upper face velocity.
-                     * @RMM added cos to g term to test terrain-following grid
-                     */
-
-                    sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
-
-                    lower_cond = pp[ip] / sep - (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p])) * dp[ip] * gravity *
-                                 z_dir_g;
-
-                    upper_cond = pp[ip + sz_p] / sep
-                                 + (z_mult_dat[ip + sz_p] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
-                                 * dp[ip + sz_p] * gravity * z_dir_g;
-
-                    diff = (lower_cond - upper_cond);
-
-
-                    u_old = ffz * del_x_slope * del_y_slope
-                            * PMeanDZ(permzp[ip], permzp[ip + sz_p],
-                                      z_mult_dat[ip], z_mult_dat[ip + sz_p])
-                            * diff
-                            * RPMean(lower_cond, upper_cond,
-                                     rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
-                            / viscosity;
-
-                    sep = dz * z_mult_dat[ip] / 2.0;
-
-                    lower_cond = (pp[ip] / sep) - 0.25 * dp[ip] * gravity * z_dir_g;
-                    upper_cond = (value / sep) + 0.25 * dp[ip] * gravity * z_dir_g;
-
-                    diff = lower_cond - upper_cond;
-                    u_new = RPMean(lower_cond, upper_cond,
-                                   rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p]);
-                    break;
-                  }         /* End case 1 */
-              }
-              u_new = u_new * ffz * del_x_slope * del_y_slope *
-                      (permzp[ip] / viscosity)
-                      * 2.0 * diff;
-            }
-
-            /* Remove the boundary term computed above */
-            fp[ip] -= dt * dir * u_old;
-
-            /* Add the correct boundary term */
-            fp[ip] += dt * dir * u_new;
-          });
-
-          break;
-        }
-
-        case FluxBC:
-        {
-          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            ip = SubvectorEltIndex(p_sub, i, j, k);
-            io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
-
-            x_dir_g = 0.0;
-            y_dir_g = 0.0;
-            z_dir_g = 1.0;
-
-            del_x_slope = 1.0;
-            del_y_slope = 1.0;
-
-            if (fdir[0])
-            {
-              switch (fdir[0])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - 1] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip - 1], pp[ip],
-                                  permxp[ip - 1], permxp[ip])
-                          * (diff / dx * del_x_slope)
-                          * RPMean(pp[ip - 1], pp[ip],
-                                   rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope
-                           * PMean(pp[ip - 1], pp[ip],
-                                   permxp[ip - 1], permxp[ip])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
-                                    rpp[ip] * dp[ip])
-                           / viscosity;
-
-
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + 1];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip], pp[ip + 1],
-                                  permxp[ip], permxp[ip + 1])
-                          * (diff / dx * del_x_slope)
-                          * RPMean(pp[ip], pp[ip + 1],
-                                   rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope
-                           * PMean(pp[ip], pp[ip + 1],
-                                   permxp[ip], permxp[ip + 1])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
-                                    rpp[ip + 1] * dp[ip + 1])
-                           / viscosity;
-
-                  break;
-              }
-              u_new = z_mult_dat[ip] * ffx;
-            }
-            else if (fdir[1])
-            {
-              switch (fdir[1])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - sy_p] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip - sy_p], pp[ip],
-                                  permyp[ip - sy_p], permyp[ip])
-                          * (diff / dy)
-                          * RPMean(pp[ip - sy_p], pp[ip],
-                                   rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope *
-                           PMean(pp[ip], pp[ip - sy_p], permyp[ip],
-                                 permyp[ip - sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip - sy_p] * dp[ip - sy_p])
-                           / viscosity;
-
-
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + sy_p];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip], pp[ip + sy_p],
-                                  permyp[ip], permyp[ip + sy_p])
-                          * (diff / dy)
-                          * RPMean(pp[ip], pp[ip + sy_p],
-                                   rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope
-                           * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
-                                   permyp[ip + sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip + sy_p] * dp[ip + sy_p])
-                           / viscosity;
-
-                  break;
-              }
-              u_new = z_mult_dat[ip] * ffy * del_x_slope;
-            }
-            else if (fdir[2])
-            {
-              switch (fdir[2])
-              {
-                case -1:
-                  dir = -1;
-                  sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
-
-                  lower_cond = (pp[ip - sz_p] / sep)
-                               - (z_mult_dat[ip - sz_p] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip - sz_p] * gravity *
-                               z_dir_g;
-
-                  upper_cond = (pp[ip] / sep) + (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip] * gravity *
-                               z_dir_g;
-
-                  diff = lower_cond - upper_cond;
-                  u_old = ffz * del_x_slope * del_y_slope
-                          * PMeanDZ(permzp[ip - sz_p], permzp[ip],
-                                    z_mult_dat[ip - sz_p], z_mult_dat[ip])
-                          * diff
-                          * RPMean(lower_cond, upper_cond,
-                                   rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
-                          / viscosity;
-                  break;
-
-                case  1:
-                  dir = 1;
-                  sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
-
-                  lower_cond = (pp[ip] / sep) - (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p])) * dp[ip] * gravity *
-                               z_dir_g;
-
-                  upper_cond = (pp[ip + sz_p] / sep)
-                               + (z_mult_dat[ip + sz_p] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p])) * dp[ip + sz_p] * gravity *
-                               z_dir_g;
-
-                  diff = lower_cond - upper_cond;
-                  u_old = ffz * del_x_slope * del_y_slope
-                          * PMeanDZ(permzp[ip], permzp[ip + sz_p],
-                                    z_mult_dat[ip], z_mult_dat[ip + sz_p])
-                          * diff
-                          * RPMean(lower_cond, upper_cond,
-                                   rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
-                          / viscosity;
-
-
-
-                  break;
-              }
-              u_new = ffz * del_x_slope * del_y_slope;
-            }
-
-            /* Remove the boundary term computed above */
-            fp[ip] -= dt * dir * u_old;
-            /* Add the correct boundary term */
-            u_new = u_new * bc_patch_values[ival];
-            fp[ip] += dt * dir * u_new;
-          });
-
-          break;
-        }         /* End fluxbc case */
-
-        case OverlandBC:
-        {
-          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            ip = SubvectorEltIndex(p_sub, i, j, k);
-            io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
-
-            x_dir_g = 0.0;
-            y_dir_g = 0.0;
-            z_dir_g = 1.0;
-
-            del_x_slope = 1.0;
-            del_y_slope = 1.0;
-
-            if (fdir[0])
-            {
-              switch (fdir[0])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - 1] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip - 1], pp[ip],
-                                  permxp[ip - 1], permxp[ip])
-                          * (diff / dx)
-                          * RPMean(pp[ip - 1], pp[ip],
-                                   rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope
-                           * PMean(pp[ip - 1], pp[ip],
-                                   permxp[ip - 1], permxp[ip])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
-                                    rpp[ip] * dp[ip])
-                           / viscosity;
-
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + 1];
-                  u_old = z_mult_dat[ip] * ffx * del_y_slope
-                          * PMean(pp[ip], pp[ip + 1],
-                                  permxp[ip], permxp[ip + 1])
-                          * (diff / dx)
-                          * RPMean(pp[ip], pp[ip + 1],
-                                   rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffx * del_y_slope
-                           * PMean(pp[ip], pp[ip + 1],
-                                   permxp[ip], permxp[ip + 1])
-                           * (-x_dir_g)
-                           * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
-                                    rpp[ip + 1] * dp[ip + 1])
-                           / viscosity;
-                  break;
-              }
-              u_new = z_mult_dat[ip] * ffx * del_y_slope;
-            }
-            else if (fdir[1])
-            {
-              switch (fdir[1])
-              {
-                case -1:
-                  dir = -1;
-                  diff = pp[ip - sy_p] - pp[ip];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip - sy_p], pp[ip],
-                                  permyp[ip - sy_p], permyp[ip])
-                          * (diff / dy)
-                          * RPMean(pp[ip - sy_p], pp[ip],
-                                   rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope *
-                           PMean(pp[ip], pp[ip - sy_p], permyp[ip],
-                                 permyp[ip - sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip - sy_p] * dp[ip - sy_p])
-                           / viscosity;
-
-                  break;
-
-                case  1:
-                  dir = 1;
-                  diff = pp[ip] - pp[ip + sy_p];
-                  u_old = z_mult_dat[ip] * ffy * del_x_slope
-                          * PMean(pp[ip], pp[ip + sy_p],
-                                  permyp[ip], permyp[ip + sy_p])
-                          * (diff / dy)
-                          * RPMean(pp[ip], pp[ip + sy_p],
-                                   rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
-                          / viscosity;
-
-                  u_old += z_mult_dat[ip] * ffy * del_x_slope
-                           * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
-                                   permyp[ip + sy_p])
-                           * (-y_dir_g)
-                           * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
-                                    rpp[ip + sy_p] * dp[ip + sy_p])
-                           / viscosity;
-
-                  break;
-              }
-              u_new = z_mult_dat[ip] * ffy * del_x_slope;
-            }
-            else if (fdir[2])
-            {
-              switch (fdir[2])
-              {
-                case -1:
-                  dir = -1;
-                  sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
-                  //  sep = dz*z_mult_dat[ip];  //RMM
-
-                  lower_cond = (pp[ip - sz_p] / sep)
-                               - (z_mult_dat[ip - sz_p] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip - sz_p] * gravity *
-                               z_dir_g;
-                  upper_cond = (pp[ip] / sep) + (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip - sz_p])) * dp[ip] * gravity *
-                               z_dir_g;
-
-                  diff = lower_cond - upper_cond;
-                  u_old = ffz * del_x_slope * del_y_slope
-                          * PMeanDZ(permzp[ip - sz_p], permzp[ip],
-                                    z_mult_dat[ip - sz_p], z_mult_dat[ip])
-                          * diff
-                          * RPMean(lower_cond, upper_cond,
-                                   rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
-                          / viscosity;
-                  break;
-
-                case  1:
-                  dir = 1;
-                  sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
-
-                  lower_cond = (pp[ip] / sep) - (z_mult_dat[ip] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p])) * dp[ip] * gravity *
-                               z_dir_g;
-                  upper_cond = (pp[ip + sz_p] / sep)
-                               + (z_mult_dat[ip + sz_p] / (z_mult_dat[ip] + z_mult_dat[ip + sz_p])) * dp[ip + sz_p] * gravity *
-                               z_dir_g;
-                  diff = lower_cond - upper_cond;
-                  u_old = ffz * del_x_slope * del_y_slope
-                          * PMeanDZ(permzp[ip], permzp[ip + sz_p],
-                                    z_mult_dat[ip], z_mult_dat[ip + sz_p])
-                          * diff
-                          * RPMean(lower_cond, upper_cond,
-                                   rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
-                          / viscosity;
-                  break;
-              }
-              u_new = ffz * del_x_slope * del_y_slope;
-            }
-
-            /* Remove the boundary term computed above */
-            fp[ip] -= dt * dir * u_old;
-            //add source boundary terms
-            u_new = u_new * bc_patch_values[ival];       //sk: here we go in and implement surface routing!
-
-            fp[ip] += dt * dir * u_new;
-          });
-
-          // SGS Fix this up later after things are a bit more stable.   Probably should
-          // Use this loop inside the overland flow eval as it is more efficient.
-#if 1
-          if (diffusive == 0)
-          {
-            /* Call overlandflow_eval to compute fluxes across the east, west, north, and south faces */
+        // Equivalent to diffusive == 0
+        PRECONDITION({
             PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module,
                                (grid, is, bc_struct, ipatch, problem_data, pressure,
                                 ke_, kw_, kn_, ks_, qx_, qy_, CALCFCN));
-          }
-          else
-          {
-            /*  @RMM this is modified to be kinematic wave routing, with a new module for diffusive wave
-             * routing added */
+            BCStructPatchLoopOvrlndX(i, j, k, ival, bc_struct, ipatch, is,
+                                    NO_PROLOGUE,
+                                    NO_EPILOGUE,
+                                    FACE(Front,
+                                    {
+                                      io = SubvectorEltIndex(qx_sub, i, j, 0);
+                                      ip = SubvectorEltIndex(p_sub, i, j, k);
+                                      double dir_x = 0.0;
+                                      double dir_y = 0.0;
+                                      if (x_sl_dat[io] > 0.0)
+                                        dir_x = -1.0;
+                                      if (x_sl_dat[io] < 0.0)
+                                        dir_x = 1.0;
+                                      if (y_sl_dat[io] > 0.0)
+                                        dir_y = -1.0;
+                                      if (y_sl_dat[io] < 0.0)
+                                        dir_y = 1.0;
+
+                                      qx_[io] = dir_x * (RPowerR(fabs(x_sl_dat[io]), 0.5)
+                                                         / mann_dat[io])
+                                                * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
+
+                                      qy_[io] = dir_y * (RPowerR(fabs(y_sl_dat[io]), 0.5)
+                                                         / mann_dat[io])
+                                                * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
+
+                                    })
+              );
+          }),
+          PROLOGUE({
+              ip = SubvectorEltIndex(p_sub, i, j, k);
+              io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
+              x_dir_g = 0.0;
+              y_dir_g = 0.0;
+              z_dir_g = 1.0;
+              del_x_slope = 1.0;
+              del_y_slope = 1.0;
+            }),
+          EPILOGUE({
+              fp[ip] -= dt * dir * u_old;
+              u_new = u_new * bc_patch_values[ival];
+              fp[ip] += dt * dir * u_new;
+            }),
+          FACE(Left, {
+              dir = -1;
+              diff = pp[ip - 1] - pp[ip];
+              u_old = z_mult_dat[ip] * ffx * del_y_slope
+                      * PMean(pp[ip - 1], pp[ip],
+                              permxp[ip - 1], permxp[ip])
+                      * (diff / dx)
+                      * RPMean(pp[ip - 1], pp[ip],
+                               rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffx * del_y_slope
+                       * PMean(pp[ip - 1], pp[ip],
+                               permxp[ip - 1], permxp[ip])
+                       * (-x_dir_g)
+                       * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
+                                rpp[ip] * dp[ip])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffx * del_y_slope;
+            }),
+          FACE(Right, {
+              dir = 1;
+              diff = pp[ip] - pp[ip + 1];
+              u_old = z_mult_dat[ip] * ffx * del_y_slope
+                      * PMean(pp[ip], pp[ip + 1],
+                              permxp[ip], permxp[ip + 1])
+                      * (diff / dx)
+                      * RPMean(pp[ip], pp[ip + 1],
+                               rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffx * del_y_slope
+                       * PMean(pp[ip], pp[ip + 1],
+                               permxp[ip], permxp[ip + 1])
+                       * (-x_dir_g)
+                       * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
+                                rpp[ip + 1] * dp[ip + 1])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffx * del_y_slope;
+            }),
+          FACE(Down, {
+              dir = -1;
+              diff = pp[ip - sy_p] - pp[ip];
+              u_old = z_mult_dat[ip] * ffy * del_x_slope
+                      * PMean(pp[ip - sy_p], pp[ip],
+                              permyp[ip - sy_p], permyp[ip])
+                      * (diff / dy)
+                      * RPMean(pp[ip - sy_p], pp[ip],
+                               rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffy * del_x_slope *
+                       PMean(pp[ip], pp[ip - sy_p], permyp[ip],
+                             permyp[ip - sy_p])
+                       * (-y_dir_g)
+                       * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
+                                rpp[ip - sy_p] * dp[ip - sy_p])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffy * del_x_slope;
+            }),
+          FACE(Up, {
+              dir = 1;
+              diff = pp[ip] - pp[ip + sy_p];
+              u_old = z_mult_dat[ip] * ffy * del_x_slope
+                      * PMean(pp[ip], pp[ip + sy_p],
+                              permyp[ip], permyp[ip + sy_p])
+                      * (diff / dy)
+                      * RPMean(pp[ip], pp[ip + sy_p],
+                               rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffy * del_x_slope
+                       * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
+                               permyp[ip + sy_p])
+                       * (-y_dir_g)
+                       * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
+                                rpp[ip + sy_p] * dp[ip + sy_p])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffy * del_x_slope;
+            }),
+          FACE(Back, {
+              dir = -1;
+              sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
+              //  sep = dz*z_mult_dat[ip];  //RMM
+
+              lower_cond = (pp[ip - sz_p] / sep)
+                           - (z_mult_dat[ip - sz_p]
+                              / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                           * dp[ip - sz_p] * gravity
+                           * z_dir_g;
+              upper_cond = (pp[ip] / sep)
+                           + (z_mult_dat[ip]
+                              / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                           * dp[ip] * gravity
+                           * z_dir_g;
+
+              diff = lower_cond - upper_cond;
+              u_old = ffz * del_x_slope * del_y_slope
+                      * PMeanDZ(permzp[ip - sz_p], permzp[ip],
+                                z_mult_dat[ip - sz_p], z_mult_dat[ip])
+                      * diff
+                      * RPMean(lower_cond, upper_cond,
+                               rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_new = ffz * del_x_slope * del_y_slope;
+            }),
+          FACE(Front, {
+              dir = 1;
+              sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
+
+              lower_cond = (pp[ip] / sep)
+                           - (z_mult_dat[ip]
+                              / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                           * dp[ip] * gravity
+                           * z_dir_g;
+              upper_cond = (pp[ip + sz_p] / sep)
+                           + (z_mult_dat[ip + sz_p]
+                              / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                           * dp[ip + sz_p] * gravity
+                           * z_dir_g;
+              diff = lower_cond - upper_cond;
+              u_old = ffz * del_x_slope * del_y_slope
+                      * PMeanDZ(permzp[ip], permzp[ip + sz_p],
+                                z_mult_dat[ip], z_mult_dat[ip + sz_p])
+                      * diff
+                      * RPMean(lower_cond, upper_cond,
+                               rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
+                      / viscosity;
+
+              u_new = ffz * del_x_slope * del_y_slope;
+
+              // Do additional loop body calculations after OvrlndLoop
+              // (No immediate dependency issues)
+              io = SubvectorEltIndex(ke_sub, i, j, 0);
+              ke_[io] = pfmax(qx_[io], 0.0) - pfmax(-qx_[io + 1], 0.0);
+              kw_[io] = pfmax(qx_[io - 1], 0.0) - pfmax(-qx_[io], 0.0);
+              kn_[io] = pfmax(qy_[io], 0.0) - pfmax(-qy_[io + sy_p], 0.0);
+              ks_[io] = pfmax(qy_[io - sy_p], 0.0) - pfmax(-qy_[io], 0.0);
+
+              io = SubvectorEltIndex(x_sl_sub, i, j, 0);
+              q_overlnd = vol
+                          * (pfmax(pp[ip], 0.0) - pfmax(opp[ip], 0.0)) / dz
+                          + dt * vol * ((ke_[io] - kw_[io]) / dx
+                                        + (kn_[io] - ks_[io]) / dy)
+                          / dz + vol * dt / dz
+                          * (exp(pfmin(pp[ip], 0.0)
+                                 * public_xtra->SpinupDampP1)
+                             * public_xtra->SpinupDampP2);
+              //NBE
+
+
+              if (overlandspinup == 1)
+              {
+                /* add flux loss equal to excess head  that overwrites the prior overland flux */
+                q_overlnd = (vol / dz) * dt
+                            * ((pfmax(pp[ip], 0.0) - 0.0)
+                               + exp(pfmin(pp[ip], 0.0)
+                                     * public_xtra->SpinupDampP1)
+                               * public_xtra->SpinupDampP2); //@RMM
+              }
+
+              fp[ip] += q_overlnd;
+            })
+          }); // End OverlandDiffusiveBC
+
+      ApplyBCPatch_WithPrecondition(OverlandKinematicBC,
+      {
+        // Equivalent to diffusive != 0
+        PRECONDITION({
             double *dummy1, *dummy2, *dummy3, *dummy4;
             PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
                                (grid, is, bc_struct, ipatch, problem_data, pressure,
                                 ke_, kw_, kn_, ks_,
                                 dummy1, dummy2, dummy3, dummy4,
                                 qx_, qy_, CALCFCN));
-          }
-#else
-          // SGS TODO can these loops be merged?
-          BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            if (fdir[2])
-            {
-              switch (fdir[2])
+            BCStructPatchLoopOvrlndX(i, j, k, ival, bc_struct, ipatch, is,
+                                    NO_PROLOGUE,
+                                    NO_EPILOGUE,
+                                    FACE(Front,
+                                    {
+                                      io = SubvectorEltIndex(qx_sub, i, j, 0);
+                                      ip = SubvectorEltIndex(p_sub, i, j, k);
+                                      double dir_x = 0.0;
+                                      double dir_y = 0.0;
+                                      if (x_sl_dat[io] > 0.0)
+                                        dir_x = -1.0;
+                                      if (x_sl_dat[io] < 0.0)
+                                        dir_x = 1.0;
+                                      if (y_sl_dat[io] > 0.0)
+                                        dir_y = -1.0;
+                                      if (y_sl_dat[io] < 0.0)
+                                        dir_y = 1.0;
+
+                                      qx_[io] = dir_x * (RPowerR(fabs(x_sl_dat[io]), 0.5)
+                                                         / mann_dat[io])
+                                                * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
+
+                                      qy_[io] = dir_y * (RPowerR(fabs(y_sl_dat[io]), 0.5)
+                                                         / mann_dat[io])
+                                                * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
+
+                                    })
+              );
+          }),
+          PROLOGUE({
+              ip = SubvectorEltIndex(p_sub, i, j, k);
+              io = SubvectorEltIndex(x_ssl_sub, i, j, grid2d_iz);
+              x_dir_g = 0.0;
+              y_dir_g = 0.0;
+              z_dir_g = 1.0;
+              del_x_slope = 1.0;
+              del_y_slope = 1.0;
+            }),
+          EPILOGUE({
+              fp[ip] -= dt * dir * u_old;
+              u_new = u_new * bc_patch_values[ival];
+              fp[ip] += dt * dir * u_new;
+            }),
+          FACE(Left, {
+              dir = -1;
+              diff = pp[ip - 1] - pp[ip];
+              u_old = z_mult_dat[ip] * ffx * del_y_slope
+                      * PMean(pp[ip - 1], pp[ip],
+                              permxp[ip - 1], permxp[ip])
+                      * (diff / dx)
+                      * RPMean(pp[ip - 1], pp[ip],
+                               rpp[ip - 1] * dp[ip - 1], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffx * del_y_slope
+                       * PMean(pp[ip - 1], pp[ip],
+                               permxp[ip - 1], permxp[ip])
+                       * (-x_dir_g)
+                       * RPMean(pp[ip - 1], pp[ip], rpp[ip - 1] * dp[ip - 1],
+                                rpp[ip] * dp[ip])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffx * del_y_slope;
+            }),
+          FACE(Right, {
+              dir = 1;
+              diff = pp[ip] - pp[ip + 1];
+              u_old = z_mult_dat[ip] * ffx * del_y_slope
+                      * PMean(pp[ip], pp[ip + 1],
+                              permxp[ip], permxp[ip + 1])
+                      * (diff / dx)
+                      * RPMean(pp[ip], pp[ip + 1],
+                               rpp[ip] * dp[ip], rpp[ip + 1] * dp[ip + 1])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffx * del_y_slope
+                       * PMean(pp[ip], pp[ip + 1],
+                               permxp[ip], permxp[ip + 1])
+                       * (-x_dir_g)
+                       * RPMean(pp[ip], pp[ip + 1], rpp[ip] * dp[ip],
+                                rpp[ip + 1] * dp[ip + 1])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffx * del_y_slope;
+            }),
+          FACE(Down, {
+              dir = -1;
+              diff = pp[ip - sy_p] - pp[ip];
+              u_old = z_mult_dat[ip] * ffy * del_x_slope
+                      * PMean(pp[ip - sy_p], pp[ip],
+                              permyp[ip - sy_p], permyp[ip])
+                      * (diff / dy)
+                      * RPMean(pp[ip - sy_p], pp[ip],
+                               rpp[ip - sy_p] * dp[ip - sy_p], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffy * del_x_slope *
+                       PMean(pp[ip], pp[ip - sy_p], permyp[ip],
+                             permyp[ip - sy_p])
+                       * (-y_dir_g)
+                       * RPMean(pp[ip], pp[ip - sy_p], rpp[ip] * dp[ip],
+                                rpp[ip - sy_p] * dp[ip - sy_p])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffy * del_x_slope;
+            }),
+          FACE(Up, {
+              dir = 1;
+              diff = pp[ip] - pp[ip + sy_p];
+              u_old = z_mult_dat[ip] * ffy * del_x_slope
+                      * PMean(pp[ip], pp[ip + sy_p],
+                              permyp[ip], permyp[ip + sy_p])
+                      * (diff / dy)
+                      * RPMean(pp[ip], pp[ip + sy_p],
+                               rpp[ip] * dp[ip], rpp[ip + sy_p] * dp[ip + sy_p])
+                      / viscosity;
+
+              u_old += z_mult_dat[ip] * ffy * del_x_slope
+                       * PMean(pp[ip], pp[ip + sy_p], permyp[ip],
+                               permyp[ip + sy_p])
+                       * (-y_dir_g)
+                       * RPMean(pp[ip], pp[ip + sy_p], rpp[ip] * dp[ip],
+                                rpp[ip + sy_p] * dp[ip + sy_p])
+                       / viscosity;
+
+              u_new = z_mult_dat[ip] * ffy * del_x_slope;
+            }),
+          FACE(Back, {
+              dir = -1;
+              sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_p]); //RMM
+              //  sep = dz*z_mult_dat[ip];  //RMM
+
+              lower_cond = (pp[ip - sz_p] / sep)
+                           - (z_mult_dat[ip - sz_p]
+                              / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                           * dp[ip - sz_p] * gravity
+                           * z_dir_g;
+              upper_cond = (pp[ip] / sep)
+                           + (z_mult_dat[ip]
+                              / (z_mult_dat[ip] + z_mult_dat[ip - sz_p]))
+                           * dp[ip] * gravity
+                           * z_dir_g;
+
+              diff = lower_cond - upper_cond;
+              u_old = ffz * del_x_slope * del_y_slope
+                      * PMeanDZ(permzp[ip - sz_p], permzp[ip],
+                                z_mult_dat[ip - sz_p], z_mult_dat[ip])
+                      * diff
+                      * RPMean(lower_cond, upper_cond,
+                               rpp[ip - sz_p] * dp[ip - sz_p], rpp[ip] * dp[ip])
+                      / viscosity;
+
+              u_new = ffz * del_x_slope * del_y_slope;
+            }),
+          FACE(Front, {
+              dir = 1;
+              sep = dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_p]); //RMM
+
+              lower_cond = (pp[ip] / sep)
+                           - (z_mult_dat[ip]
+                              / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                           * dp[ip] * gravity
+                           * z_dir_g;
+              upper_cond = (pp[ip + sz_p] / sep)
+                           + (z_mult_dat[ip + sz_p]
+                              / (z_mult_dat[ip] + z_mult_dat[ip + sz_p]))
+                           * dp[ip + sz_p] * gravity
+                           * z_dir_g;
+              diff = lower_cond - upper_cond;
+              u_old = ffz * del_x_slope * del_y_slope
+                      * PMeanDZ(permzp[ip], permzp[ip + sz_p],
+                                z_mult_dat[ip], z_mult_dat[ip + sz_p])
+                      * diff
+                      * RPMean(lower_cond, upper_cond,
+                               rpp[ip] * dp[ip], rpp[ip + sz_p] * dp[ip + sz_p])
+                      / viscosity;
+
+              u_new = ffz * del_x_slope * del_y_slope;
+
+              // Do additional loop body calculations after OvrlndLoop
+              // (No immediate dependency issues)
+              io = SubvectorEltIndex(ke_sub, i, j, 0);
+              ke_[io] = pfmax(qx_[io], 0.0) - pfmax(-qx_[io + 1], 0.0);
+              kw_[io] = pfmax(qx_[io - 1], 0.0) - pfmax(-qx_[io], 0.0);
+              kn_[io] = pfmax(qy_[io], 0.0) - pfmax(-qy_[io + sy_p], 0.0);
+              ks_[io] = pfmax(qy_[io - sy_p], 0.0) - pfmax(-qy_[io], 0.0);
+
+              io = SubvectorEltIndex(x_sl_sub, i, j, 0);
+              q_overlnd = vol
+                          * (pfmax(pp[ip], 0.0) - pfmax(opp[ip], 0.0)) / dz
+                          + dt * vol * ((ke_[io] - kw_[io]) / dx
+                                        + (kn_[io] - ks_[io]) / dy)
+                          / dz + vol * dt / dz
+                          * (exp(pfmin(pp[ip], 0.0)
+                                 * public_xtra->SpinupDampP1)
+                             * public_xtra->SpinupDampP2);
+              //NBE
+
+
+              if (overlandspinup == 1)
               {
-                case 1:
-                  io = SubvectorEltIndex(qx_sub, i, j, 0);
-                  ip = SubvectorEltIndex(p_sub, i, j, k);
-
-                  double dir_x = 0.0;
-                  double dir_y = 0.0;
-                  if (x_sl_dat[io] > 0.0)
-                    dir_x = -1.0;
-                  if (y_sl_dat[io] > 0.0)
-                    dir_y = -1.0;
-                  if (x_sl_dat[io] < 0.0)
-                    dir_x = 1.0;
-                  if (y_sl_dat[io] < 0.0)
-                    dir_y = 1.0;
-
-                  qx_[io] = dir_x * (RPowerR(fabs(x_sl_dat[io]), 0.5) / mann_dat[io]) * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
-
-                  qy_[io] = dir_y * (RPowerR(fabs(y_sl_dat[io]), 0.5) / mann_dat[io]) * RPowerR(pfmax((pp[ip]), 0.0), (5.0 / 3.0));
-
-                  break;
+                /* add flux loss equal to excess head  that overwrites the prior overland flux */
+                q_overlnd = (vol / dz) * dt
+                            * ((pfmax(pp[ip], 0.0) - 0.0)
+                               + exp(pfmin(pp[ip], 0.0)
+                                     * public_xtra->SpinupDampP1)
+                               * public_xtra->SpinupDampP2); //@RMM
               }
-            }
-          });
 
-          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            if (fdir[2])
-            {
-              switch (fdir[2])
-              {
-                case 1:
-                  io = SubvectorEltIndex(ke_sub, i, j, 0);
-
-                  ke_[io] = pfmax(qx_[io], 0.0) - pfmax(-qx_[io + 1], 0.0);
-                  kw_[io] = pfmax(qx_[io - 1], 0.0) - pfmax(-qx_[io], 0.0);
-
-                  kn_[io] = pfmax(qy_[io], 0.0) - pfmax(-qy_[io + sy_p], 0.0);
-                  ks_[io] = pfmax(qy_[io - sy_p], 0.0) - pfmax(-qy_[io], 0.0);
-
-                  break;
-              }
-            }
-          });
-#endif
-
-
-
-          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
-          {
-            if (fdir[2])
-            {
-              switch (fdir[2])
-              {
-                case 1:
-                  dir = 1;
-                  ip = SubvectorEltIndex(p_sub, i, j, k);
-                  io = SubvectorEltIndex(x_sl_sub, i, j, 0);
-
-                  q_overlnd = 0.0;
-
-
-                  q_overlnd = vol
-                              * (pfmax(pp[ip], 0.0) - pfmax(opp[ip], 0.0)) / dz +
-                              dt * vol * ((ke_[io] - kw_[io]) / dx + (kn_[io] - ks_[io]) / dy)
-                              / dz + vol * dt / dz * (exp(pfmin(pp[ip], 0.0) * public_xtra->SpinupDampP1) * public_xtra->SpinupDampP2);
-                  //NBE
-
-
-                  if (overlandspinup == 1)
-                  {
-                    /* add flux loss equal to excess head  that overwrites the prior overland flux */
-                    q_overlnd = (vol / dz) * dt * ((pfmax(pp[ip], 0.0) - 0.0) + exp(pfmin(pp[ip], 0.0) *
-                                                                                    public_xtra->SpinupDampP1) * public_xtra->SpinupDampP2); //@RMM
-                  }
-
-
-
-                  fp[ip] += q_overlnd;
-
-                  break;
-              }
-            }
-          });
-
-          break;
-        }         /* End OverlandBC case */
-      }        /* End switch BCtype */
-    }          /* End ipatch loop */
+              fp[ip] += q_overlnd;
+            })
+          }); // End OverlandKinematicBC
+    }); // End Do_BCContrib
   }            /* End subgrid loop */
 
   /*

--- a/pfsimulator/parflow_lib/problem_bc.h
+++ b/pfsimulator/parflow_lib/problem_bc.h
@@ -116,9 +116,9 @@ typedef struct {
     int PV_ix = SubgridIX(PV_subgrid) - 1;                              \
     int PV_iy = SubgridIY(PV_subgrid) - 1;                              \
     int PV_iz = SubgridIZ(PV_subgrid) - 1;                              \
-    int PV_nx = SubgridNX(PV_subgrid);                                  \
-    int PV_ny = SubgridNY(PV_subgrid);                                  \
-    int PV_nz = SubgridNZ(PV_subgrid);                                  \
+    int PV_nx = SubgridNX(PV_subgrid) + 2;                              \
+    int PV_ny = SubgridNY(PV_subgrid) + 2;                              \
+    int PV_nz = SubgridNZ(PV_subgrid) + 2;                              \
                                                                         \
     ival = 0;                                                           \
     GrGeomPatchLoopX(i, j, k, fdir, PV_gr_domain, PV_patch_index,       \

--- a/pfsimulator/parflow_lib/problem_bc.h
+++ b/pfsimulator/parflow_lib/problem_bc.h
@@ -73,6 +73,39 @@ typedef struct {
 #define BCStructPatchValues(bc_struct, p, s)  ((bc_struct)->values[p][s])
 
 /*--------------------------------------------------------------------------
+ * Patch iterator macro:
+ *--------------------------------------------------------------------------*/
+
+#define ForBCStructNumPatches(ipatch, bc_struct)  \
+  for(ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
+
+/*--------------------------------------------------------------------------
+ * Experimental Looping macro.  Does not need fdir, expects the use of
+ * PROLOGUE, EPILOGUE, and FACE macros to determine physics.
+ *--------------------------------------------------------------------------*/
+
+#define BCStructPatchLoopX(i, j, k, ival, bc_struct, ipatch, is,        \
+                           prologue, epilogue, ...)                     \
+  {                                                                     \
+    GrGeomSolid  *PV_gr_domain = BCStructGrDomain(bc_struct);           \
+    int PV_patch_index = BCStructPatchIndex(bc_struct, ipatch);         \
+    Subgrid      *PV_subgrid = BCStructSubgrid(bc_struct, is);          \
+                                                                        \
+    int PV_r = SubgridRX(PV_subgrid);                                   \
+    int PV_ix = SubgridIX(PV_subgrid);                                  \
+    int PV_iy = SubgridIY(PV_subgrid);                                  \
+    int PV_iz = SubgridIZ(PV_subgrid);                                  \
+    int PV_nx = SubgridNX(PV_subgrid);                                  \
+    int PV_ny = SubgridNY(PV_subgrid);                                  \
+    int PV_nz = SubgridNZ(PV_subgrid);                                  \
+                                                                        \
+    ival = 0;                                                           \
+    GrGeomPatchLoopX(i, j, k, fdir, PV_gr_domain, PV_patch_index,       \
+                     PV_r, PV_ix, PV_iy, PV_iz, PV_nx, PV_ny, PV_nz,    \
+                     prologue, { epilogue; ival++; }, __VA_ARGS__);     \
+  }
+
+/*--------------------------------------------------------------------------
  * Looping macro:
  *--------------------------------------------------------------------------*/
 

--- a/pfsimulator/parflow_lib/problem_bc.h
+++ b/pfsimulator/parflow_lib/problem_bc.h
@@ -81,7 +81,7 @@ typedef struct {
 
 /*--------------------------------------------------------------------------
  * Experimental Looping macro.  Does not need fdir, expects the use of
- * PROLOGUE, EPILOGUE, and FACE macros to determine physics.
+ * PROLOGUE, EPILOGUE, and FACE macros (bc_face.h) to determine physics.
  *--------------------------------------------------------------------------*/
 
 #define BCStructPatchLoopX(i, j, k, ival, bc_struct, ipatch, is,        \
@@ -105,6 +105,7 @@ typedef struct {
                      prologue, { epilogue; ival++; }, __VA_ARGS__);     \
   }
 
+// Same type of loop change as BCStructPatchLoopX but with overland offsets
 #define BCStructPatchLoopOvrlndX(i, j, k, ival, bc_struct, ipatch, is,  \
                                  prologue, epilogue, ...)               \
   {                                                                     \

--- a/pfsimulator/parflow_lib/problem_bc.h
+++ b/pfsimulator/parflow_lib/problem_bc.h
@@ -105,6 +105,27 @@ typedef struct {
                      prologue, { epilogue; ival++; }, __VA_ARGS__);     \
   }
 
+#define BCStructPatchLoopOvrlndX(i, j, k, ival, bc_struct, ipatch, is,  \
+                                 prologue, epilogue, ...)               \
+  {                                                                     \
+    GrGeomSolid  *PV_gr_domain = BCStructGrDomain(bc_struct);           \
+    int PV_patch_index = BCStructPatchIndex(bc_struct, ipatch);         \
+    Subgrid      *PV_subgrid = BCStructSubgrid(bc_struct, is);          \
+                                                                        \
+    int PV_r = SubgridRX(PV_subgrid);                                   \
+    int PV_ix = SubgridIX(PV_subgrid) - 1;                              \
+    int PV_iy = SubgridIY(PV_subgrid) - 1;                              \
+    int PV_iz = SubgridIZ(PV_subgrid) - 1;                              \
+    int PV_nx = SubgridNX(PV_subgrid);                                  \
+    int PV_ny = SubgridNY(PV_subgrid);                                  \
+    int PV_nz = SubgridNZ(PV_subgrid);                                  \
+                                                                        \
+    ival = 0;                                                           \
+    GrGeomPatchLoopX(i, j, k, fdir, PV_gr_domain, PV_patch_index,       \
+                     PV_r, PV_ix, PV_iy, PV_iz, PV_nx, PV_ny, PV_nz,    \
+                     prologue, { epilogue; ival++; }, __VA_ARGS__);     \
+  }
+
 /*--------------------------------------------------------------------------
  * Looping macro:
  *--------------------------------------------------------------------------*/

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -493,36 +493,24 @@ void    RichardsJacobianEval(
 
     pp = SubvectorData(p_sub);
 
-
-    Do_AddDirichletBC_Pressure(i, j, k, is, ival, ipatch, bc_struct, bc_patch_values,
+    ForBCStructNumPathces(ipatch, bc_struct)
     {
-      ApplyBCPatch(DirichletBC,
-                   PROLOGUE({
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       value = bc_patch_values[ival];
-                     }),
-                   NO_EPILOGUE,
-                   FACE(Left, {
-                       pp[ip - 1] = value;
-                     }),
-                   FACE(Right, {
-                       pp[ip + 1] = value;
-                     }),
-                   FACE(Down, {
-                       pp[ip - sy_v] = value;
-                     }),
-                   FACE(Up, {
-                       pp[ip + sy_v] = value;
-                     }),
-                   FACE(Back, {
-                       pp[ip - sz_v] = value;
-                     }),
-                   FACE(Front, {
-                       pp[ip + sz_v] = value;
-                     })
-                   ); // End DirichletBC
-    }); /* End Do_AddDirichletBC_Pressure */
-  }            /* End subgrid loop */
+      bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);
+      switch(BCStructBCType(bc_struct, ipatch))
+      {
+        case DirichletBC:
+        {
+          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+          {
+            ip = SubvectorEltIndex(p_sub, i, j, k);
+            value = bc_patch_values[ival];
+            pp[ip + fdir[0] * 1 + fdir[1] * sy_v + fdir[2] * sz_v] = value;
+          });
+          break;
+        }
+      }                         /* End switch BCtype */
+    }                           /* End ipatch loop */
+  }                             /* End subgrid loop */
 
   /* Calculate rel_perm and rel_perm_der */
 

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -994,7 +994,7 @@ void    RichardsJacobianEval(
     permyp = SubvectorData(permy_sub);
     permzp = SubvectorData(permz_sub);
 
-    Do_Richards_BCContrib(i, j, k, ival, bc_struct, ipatch, is, bc_patch_values,
+    Do_BCContrib(i, j, k, ival, bc_struct, ipatch, is, bc_patch_values,
     {
       ApplyBCPatch(DirichletBC,
                    PROLOGUE({

--- a/pfsimulator/parflow_lib/rjebak.c
+++ b/pfsimulator/parflow_lib/rjebak.c
@@ -465,9 +465,7 @@ void    RichardsJacobianEval(
       iv = SubvectorEltIndex(d_sub, i, j, k);
       vol2 = vol * z_mult_dat[ipo];
       cp[im] += (sdp[iv] * dp[iv] + sp[iv] * ddp[iv])
-                * pop[ipo] * vol2 + ss[iv] * vol2
-                * (sdp[iv] * dp[iv] * pp[iv] + sp[iv]
-                   * ddp[iv] * pp[iv] + sp[iv] * dp[iv]); //sk start
+                * pop[ipo] * vol2 + ss[iv] * vol2 * (sdp[iv] * dp[iv] * pp[iv] + sp[iv] * ddp[iv] * pp[iv] + sp[iv] * dp[iv]); //sk start
     });
   }    /* End subgrid loop */
 
@@ -493,35 +491,24 @@ void    RichardsJacobianEval(
 
     pp = SubvectorData(p_sub);
 
-
-    Do_AddDirichletBC_Pressure(i, j, k, is, ival, ipatch, bc_struct, bc_patch_values,
+    for (ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
     {
-      ApplyBCPatch(DirichletBC,
-                   PROLOGUE({
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       value = bc_patch_values[ival];
-                     }),
-                   NO_EPILOGUE,
-                   FACE(Left, {
-                       pp[ip - 1] = value;
-                     }),
-                   FACE(Right, {
-                       pp[ip + 1] = value;
-                     }),
-                   FACE(Down, {
-                       pp[ip - sy_v] = value;
-                     }),
-                   FACE(Up, {
-                       pp[ip + sy_v] = value;
-                     }),
-                   FACE(Back, {
-                       pp[ip - sz_v] = value;
-                     }),
-                   FACE(Front, {
-                       pp[ip + sz_v] = value;
-                     })
-                   ); // End DirichletBC
-    }); /* End Do_AddDirichletBC_Pressure */
+      bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);
+
+      switch (BCStructBCType(bc_struct, ipatch))
+      {
+        case DirichletBC:
+        {
+          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+          {
+            ip = SubvectorEltIndex(p_sub, i, j, k);
+            value = bc_patch_values[ival];
+            pp[ip + fdir[0] * 1 + fdir[1] * sy_v + fdir[2] * sz_v] = value;
+          });
+          break;
+        }
+      }        /* End switch BCtype */
+    }          /* End ipatch loop */
   }            /* End subgrid loop */
 
   /* Calculate rel_perm and rel_perm_der */
@@ -815,104 +802,134 @@ void    RichardsJacobianEval(
       permyp = SubvectorData(permy_sub);
       permzp = SubvectorData(permz_sub);
 
-      Do_Richards_SymmContrib(i, j, k, ival, bc_struct, ipatch, is,
+      for (ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
       {
-        ApplyBCPatch(AllBCTypes,
-                     PROLOGUE({
-                         ip = SubvectorEltIndex(p_sub, i, j, k);
-                         im = SubmatrixEltIndex(J_sub, i, j, k);
-                         prod = rpp[ip] * dp[ip];
-                       }),
-                     NO_EPILOGUE,
-                     FACE(Left, {
-                         diff = pp[ip - 1] - pp[ip];
-                         prod_der = rpdp[ip - 1] * dp[ip - 1] + rpp[ip - 1] * ddp[ip - 1];
-                         coeff = dt * z_mult_dat[ip] * ffx * (1.0 / dx)
-                                 * PMean(pp[ip - 1], pp[ip], permxp[ip - 1], permxp[ip])
-                                 / viscosity;
-                         wp[im] = -coeff * diff
-                                  * RPMean(pp[ip - 1], pp[ip], prod_der, 0.0);
-                       }),
-                     FACE(Right, {
-                         diff = pp[ip] - pp[ip + 1];
-                         prod_der = rpdp[ip + 1] * dp[ip + 1] + rpp[ip + 1] * ddp[ip + 1];
-                         coeff = dt * z_mult_dat[ip] * ffx * (1.0 / dx)
-                                 * PMean(pp[ip], pp[ip + 1], permxp[ip], permxp[ip + 1])
-                                 / viscosity;
-                         ep[im] = coeff * diff
-                                  * RPMean(pp[ip], pp[ip + 1], 0.0, prod_der);
-                       }),
-                     FACE(Down, {
-                         diff = pp[ip - sy_v] - pp[ip];
-                         prod_der = rpdp[ip - sy_v] * dp[ip - sy_v]
-                                    + rpp[ip - sy_v] * ddp[ip - sy_v];
-                         coeff = dt * z_mult_dat[ip] * ffy * (1.0 / dy)
-                                 * PMean(pp[ip - sy_v], pp[ip],
-                                         permyp[ip - sy_v], permyp[ip])
-                                 / viscosity;
-                         sop[im] = -coeff * diff
-                                   * RPMean(pp[ip - sy_v], pp[ip], prod_der, 0.0);
-                       }),
-                     FACE(Up, {
-                         diff = pp[ip] - pp[ip + sy_v];
-                         prod_der = rpdp[ip + sy_v] * dp[ip + sy_v]
-                                    + rpp[ip + sy_v] * ddp[ip + sy_v];
-                         coeff = dt * z_mult_dat[ip] * ffy * (1.0 / dy)
-                                 * PMean(pp[ip], pp[ip + sy_v],
-                                         permyp[ip], permyp[ip + sy_v])
-                                 / viscosity;
-                         np[im] = -coeff * diff
-                                  * RPMean(pp[ip], pp[ip + sy_v], 0.0, prod_der);
-                       }),
-                     FACE(Back, {
-                         lower_cond = (pp[ip - sz_v])
+        BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+        {
+          ip = SubvectorEltIndex(p_sub, i, j, k);
+          im = SubmatrixEltIndex(J_sub, i, j, k);
+
+          // SGS added this as prod was not being set to anything. Check with carol.
+          prod = rpp[ip] * dp[ip];
+
+          if (fdir[0])
+          {
+            switch (fdir[0])
+            {
+              case -1:
+                {
+                  diff = pp[ip - 1] - pp[ip];
+                  prod_der = rpdp[ip - 1] * dp[ip - 1] + rpp[ip - 1] * ddp[ip - 1];
+                  coeff = dt * z_mult_dat[ip] * ffx * (1.0 / dx)
+                          * PMean(pp[ip - 1], pp[ip], permxp[ip - 1], permxp[ip])
+                          / viscosity;
+                  wp[im] = -coeff * diff
+                           * RPMean(pp[ip - 1], pp[ip], prod_der, 0.0);
+                  break;
+                }
+
+              case 1:
+                {
+                  diff = pp[ip] - pp[ip + 1];
+                  prod_der = rpdp[ip + 1] * dp[ip + 1] + rpp[ip + 1] * ddp[ip + 1];
+                  coeff = dt * z_mult_dat[ip] * ffx * (1.0 / dx)
+                          * PMean(pp[ip], pp[ip + 1], permxp[ip], permxp[ip + 1])
+                          / viscosity;
+                  ep[im] = coeff * diff
+                           * RPMean(pp[ip], pp[ip + 1], 0.0, prod_der);
+                  break;
+                }
+            }         /* End switch on fdir[0] */
+          }           /* End if (fdir[0]) */
+
+          else if (fdir[1])
+          {
+            switch (fdir[1])
+            {
+              case -1:
+                {
+                  diff = pp[ip - sy_v] - pp[ip];
+                  prod_der = rpdp[ip - sy_v] * dp[ip - sy_v]
+                             + rpp[ip - sy_v] * ddp[ip - sy_v];
+                  coeff = dt * z_mult_dat[ip] * ffy * (1.0 / dy)
+                          * PMean(pp[ip - sy_v], pp[ip],
+                                  permyp[ip - sy_v], permyp[ip])
+                          / viscosity;
+                  sop[im] = -coeff * diff
+                            * RPMean(pp[ip - sy_v], pp[ip], prod_der, 0.0);
+
+                  break;
+                }
+
+              case 1:
+                {
+                  diff = pp[ip] - pp[ip + sy_v];
+                  prod_der = rpdp[ip + sy_v] * dp[ip + sy_v]
+                             + rpp[ip + sy_v] * ddp[ip + sy_v];
+                  coeff = dt * z_mult_dat[ip] * ffy * (1.0 / dy)
+                          * PMean(pp[ip], pp[ip + sy_v],
+                                  permyp[ip], permyp[ip + sy_v])
+                          / viscosity;
+                  np[im] = -coeff * diff
+                           * RPMean(pp[ip], pp[ip + sy_v], 0.0, prod_der);
+                  break;
+                }
+            }         /* End switch on fdir[1] */
+          }           /* End if (fdir[1]) */
+
+          else if (fdir[2])
+          {
+            switch (fdir[2])
+            {
+              case -1:
+                {
+                  lower_cond = (pp[ip - sz_v])
                                - 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v])
                                * dp[ip - sz_v] * gravity;
-                         upper_cond = (pp[ip]) + 0.5 * dz
-                                      * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v])
-                                      * dp[ip] * gravity;
-                         diff = lower_cond - upper_cond;
-                         prod_der = rpdp[ip - sz_v] * dp[ip - sz_v]
-                                    + rpp[ip - sz_v] * ddp[ip - sz_v];
-                         prod_lo = rpp[ip - sz_v] * dp[ip - sz_v];
-                         coeff = dt * ffz
-                                 * (1.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v])))
-                                 * PMeanDZ(permzp[ip - sz_v], permzp[ip],
-                                           z_mult_dat[ip - sz_v], z_mult_dat[ip])
-                                 / viscosity;
-                         lp[im] = -coeff *
-                                  (diff * RPMean(lower_cond, upper_cond,
-                                                 prod_der, 0.0)
-                                   - gravity * 0.5 * dz
-                                   * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v]) * ddp[ip]
-                                   * RPMean(lower_cond, upper_cond, prod_lo, prod));
-                       }),
-                     FACE(Front, {
-                         lower_cond = (pp[ip])
-                                      - 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])
-                                      * dp[ip] * gravity;
-                         upper_cond = (pp[ip + sz_v])
-                                      + 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])
-                                      * dp[ip + sz_v] * gravity;
-                         diff = lower_cond - upper_cond;
-                         prod_der = rpdp[ip + sz_v] * dp[ip + sz_v]
-                                    + rpp[ip + sz_v] * ddp[ip + sz_v];
-                         prod_up = rpp[ip + sz_v] * dp[ip + sz_v];
-                         coeff = dt * ffz
-                                 * (1.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])))
-                                 * PMeanDZ(permzp[ip], permzp[ip + sz_v],
-                                           z_mult_dat[ip], z_mult_dat[ip + sz_v])
-                                 / viscosity;
-                         up[im] = -coeff *
-                                  (diff * RPMean(lower_cond, upper_cond,
-                                                 0.0, prod_der)
-                                   - gravity * 0.5 * dz
-                                   * (Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])) * ddp[ip]
-                                   * RPMean(lower_cond, upper_cond, prod, prod_up));
-                       })
-                     ); // End AllBCTypes
+                  upper_cond = (pp[ip]) + 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v])
+                               * dp[ip] * gravity;
+                  diff = lower_cond - upper_cond;
+                  prod_der = rpdp[ip - sz_v] * dp[ip - sz_v]
+                             + rpp[ip - sz_v] * ddp[ip - sz_v];
+                  prod_lo = rpp[ip - sz_v] * dp[ip - sz_v];
+                  coeff = dt * ffz * (1.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v])))
+                          * PMeanDZ(permzp[ip - sz_v], permzp[ip],
+                                    z_mult_dat[ip - sz_v], z_mult_dat[ip])
+                          / viscosity;
+                  lp[im] = -coeff *
+                           (diff * RPMean(lower_cond, upper_cond,
+                                          prod_der, 0.0)
+                            - gravity * 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v]) * ddp[ip]
+                            * RPMean(lower_cond, upper_cond, prod_lo, prod));
 
-      });
+                  break;
+                }
+
+              case 1:
+                {
+                  lower_cond = (pp[ip]) - 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * dp[ip] * gravity;
+                  upper_cond = (pp[ip + sz_v])
+                               + 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * dp[ip + sz_v] * gravity;
+                  diff = lower_cond - upper_cond;
+                  prod_der = rpdp[ip + sz_v] * dp[ip + sz_v]
+                             + rpp[ip + sz_v] * ddp[ip + sz_v];
+                  prod_up = rpp[ip + sz_v] * dp[ip + sz_v];
+                  coeff = dt * ffz * (1.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])))
+                          * PMeanDZ(permzp[ip], permzp[ip + sz_v],
+                                    z_mult_dat[ip], z_mult_dat[ip + sz_v])
+                          / viscosity;
+                  up[im] = -coeff *
+                           (diff * RPMean(lower_cond, upper_cond,
+                                          0.0, prod_der)
+                            - gravity * 0.5 * dz * (Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])) * ddp[ip]
+                            * RPMean(lower_cond, upper_cond, prod, prod_up));
+
+                  break;
+                }
+            }         /* End switch on fdir[2] */
+          }        /* End if (fdir[2]) */
+        });       /* End Patch Loop */
+      }           /* End ipatch loop */
     }             /* End subgrid loop */
   }                  /* End if symm_part */
 
@@ -994,248 +1011,290 @@ void    RichardsJacobianEval(
     permyp = SubvectorData(permy_sub);
     permzp = SubvectorData(permz_sub);
 
-    Do_Richards_BCContrib(i, j, k, ival, bc_struct, ipatch, is, bc_patch_values,
+    for (ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
     {
-      ApplyBCPatch(DirichletBC,
-                   PROLOGUE({
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                       value = bc_patch_values[ival];
-                       prod = rpp[ip] * dp[ip];
-                       prod_der = rpdp[ip] * dp[ip]
-                                  + rpp[ip] * ddp[ip];
-                       PFModuleInvokeType(PhaseDensityInvoke, density_module,
-                                          (0, NULL, NULL, &value, &den_d, CALCFCN));
-                       PFModuleInvokeType(PhaseDensityInvoke, density_module,
-                                          (0, NULL, NULL, &value, &dend_d, CALCDER));
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       cp[im] -= o_temp;
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left, {
-                       op = wp;
-                       coeff = dt * ffx * z_mult_dat[ip] * (2.0 / dx) * permxp[ip] / viscosity;
-                       prod_val = rpp[ip - 1] * den_d;
-                       diff = value - pp[ip];
-                       o_temp = coeff
-                                * (diff * RPMean(value, pp[ip], 0.0, prod_der)
-                                   - RPMean(value, pp[ip], prod_val, prod));
-                     }),
-                   FACE(Right, {
-                       op = ep;
-                       coeff = dt * ffx * z_mult_dat[ip] * (2.0 / dx) * permxp[ip] / viscosity;
-                       prod_val = rpp[ip + 1] * den_d;
-                       diff = pp[ip] - value;
-                       o_temp = -coeff
-                                * (diff * RPMean(pp[ip], value, prod_der, 0.0)
-                                   + RPMean(pp[ip], value, prod, prod_val));
-                     }),
-                   FACE(Down, {
-                       op = sop;
-                       coeff = dt * ffy * z_mult_dat[ip] * (2.0 / dy) * permyp[ip] / viscosity;
-                       prod_val = rpp[ip - sy_v] * den_d;
-                       diff = value - pp[ip];
-                       o_temp = coeff
-                                * (diff * RPMean(value, pp[ip], 0.0, prod_der)
-                                   - RPMean(value, pp[ip], prod_val, prod));
-                     }),
-                   FACE(Up, {
-                       op = np;
-                       coeff = dt * ffy * z_mult_dat[ip] * (2.0 / dy) * permyp[ip] / viscosity;
-                       prod_val = rpp[ip + sy_v] * den_d;
-                       diff = pp[ip] - value;
-                       o_temp = -coeff
-                                * (diff * RPMean(pp[ip], value, prod_der, 0.0)
-                                   + RPMean(pp[ip], value, prod, prod_val));
-                     }),
-                   FACE(Back, {
-                       op = lp;
-                       coeff = dt * ffz
-                               * (2.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])))
-                               * permzp[ip] / viscosity;
-                       prod_val = rpp[ip - sz_v] * den_d;
-                       lower_cond = (value) - 0.5 * dz * z_mult_dat[ip] * den_d * gravity;
-                       upper_cond = (pp[ip]) + 0.5 * dz * z_mult_dat[ip] * dp[ip] * gravity;
-                       diff = lower_cond - upper_cond;
+      bc_patch_values = BCStructPatchValues(bc_struct, ipatch, is);
 
-                       o_temp = coeff
-                                * (diff * RPMean(lower_cond, upper_cond, 0.0, prod_der)
-                                   + ((-1.0 - gravity * 0.5 * dz
-                                       * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v]) * ddp[ip])
-                                      * RPMean(lower_cond, upper_cond, prod_val, prod)));
-                     }),
-                   FACE(Front, {
-                       op = up;
-                       coeff = dt * ffz
-                               * (2.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])))
-                               * permzp[ip] / viscosity;
-                       prod_val = rpp[ip + sz_v] * den_d;
-                       lower_cond = (pp[ip]) - 0.5 * dz
-                                    * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])
-                                    * dp[ip] * gravity;
-                       upper_cond = (value) + 0.5 * dz
-                                    * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])
-                                    * den_d * gravity;
-                       diff = lower_cond - upper_cond;
+      switch (BCStructBCType(bc_struct, ipatch))
+      {
+        case DirichletBC:
+        {
+          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+          {
+            ip = SubvectorEltIndex(p_sub, i, j, k);
 
-                       o_temp = -coeff
-                                * (diff * RPMean(lower_cond, upper_cond, prod_der, 0.0)
-                                   + ((1.0 - gravity * 0.5 * dz
-                                       * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * ddp[ip])
-                                      * RPMean(lower_cond, upper_cond, prod, prod_val)));
-                     })
-                   ); // End DirichletBC
-      ApplyBCPatch(FluxBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, { op = up; })
-                   ); // End FluxBC
-      ApplyBCPatch(OverlandNoNonlinearBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, {
-                       op = up;
-                       if (!ovlnd_flag)
-                       {
-                         ip = SubvectorEltIndex(p_sub, i, j, k);
-                         if ((pp[ip]) > 0.0)
-                         {
-                           ovlnd_flag =1;
-                         }
-                       }
-                     })
-                   ); // End OverlandNoNonlinearBC
-      ApplyBCPatch(OverlandNotSetBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, {
-                       op = up;
-                       if (!ovlnd_flag)
-                       {
-                         ip = SubvectorEltIndex(p_sub, i, j, k);
-                         if ((pp[ip]) > 0.0)
-                         {
-                           ovlnd_flag =1;
-                         }
-                       }
-                     })
-                   ); // End OverlandNotSetBC
-      ApplyBCPatch(OverlandSimpleBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, {
-                       op = up;
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       if ((pp[ip]) > 0.0)
-                       {
-                         cp[im] += (vol * z_mult_dat[ip])
-                                   / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]))
-                                   * (dt + 1);
-                         if (!ovlnd_flag)
-                         {
-                           ovlnd_flag = 1;
-                         }
-                       }
-                     })
-                   ); // End OverlandSimpleBC
-      ApplyBCPatch(OverlandSpinupBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, {
-                       op = up;
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       vol = dx * dy * dz;
-                       if (pp[ip] >= 0.0) {
-                         cp[im] += (vol / dz) * dt * (1.0 + 0.0); // LEC
-                         if (!ovlnd_flag) {
-                           ovlnd_flag = 1;
-                         }
-                       }
-                       else
-                       {
-                         cp[im] += 0.0;
-                       }
-                     })
-                   ); // End OverlandSpinupBC
-      /* TODO: Need to add some sort of Post-Loop param to all for kinematic/diffusive calls */
-      ApplyBCPatch(OverlandDiffusiveBC,
-                   PROLOGUE({
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
-                     }),
-                   EPILOGUE({
-                       cp[im] += op[im];
-                       op[im] = 0.0;
-                     }),
-                   FACE(Left,  { op = wp; }),
-                   FACE(Right, { op = ep; }),
-                   FACE(Down,  { op = sop;}),
-                   FACE(Up,    { op = np; }),
-                   FACE(Back,  { op = lp; }),
-                   FACE(Front, {
-                       op = up;
-                       if (!ovlnd_flag)
-                       {
-                         ip = SubvectorEltIndex(p_sub, i, j, k);
-                         if ((pp[ip]) > 0.0)
-                         {
-                           ovlnd_flag = 1;
-                         }
-                       }
-                     })
-                   ); // End OverlandDiffusiveBC
-    }); // End Do_Richards_BCContrib
+            value = bc_patch_values[ival];
+
+            PFModuleInvokeType(PhaseDensityInvoke, density_module,
+                               (0, NULL, NULL, &value, &den_d, CALCFCN));
+            PFModuleInvokeType(PhaseDensityInvoke, density_module,
+                               (0, NULL, NULL, &value, &dend_d, CALCDER));
+
+            ip = SubvectorEltIndex(p_sub, i, j, k);
+            im = SubmatrixEltIndex(J_sub, i, j, k);
+
+            prod = rpp[ip] * dp[ip];
+            prod_der = rpdp[ip] * dp[ip] + rpp[ip] * ddp[ip];
+
+            if (fdir[0])
+            {
+              coeff = dt * ffx * z_mult_dat[ip] * (2.0 / dx) * permxp[ip] / viscosity;
+
+              switch (fdir[0])
+              {
+                case -1:
+                  {
+                    op = wp;
+                    prod_val = rpp[ip - 1] * den_d;
+                    diff = value - pp[ip];
+                    o_temp = coeff
+                             * (diff * RPMean(value, pp[ip], 0.0, prod_der)
+                                - RPMean(value, pp[ip], prod_val, prod));
+                    break;
+                  }
+
+                case 1:
+                  {
+                    op = ep;
+                    prod_val = rpp[ip + 1] * den_d;
+                    diff = pp[ip] - value;
+                    o_temp = -coeff
+                             * (diff * RPMean(pp[ip], value, prod_der, 0.0)
+                                + RPMean(pp[ip], value, prod, prod_val));
+                    break;
+                  }
+              }          /* End switch on fdir[0] */
+            }            /* End if (fdir[0]) */
+
+            else if (fdir[1])
+            {
+              coeff = dt * ffy * z_mult_dat[ip] * (2.0 / dy) * permyp[ip] / viscosity;
+
+              switch (fdir[1])
+              {
+                case -1:
+                  {
+                    op = sop;
+                    prod_val = rpp[ip - sy_v] * den_d;
+                    diff = value - pp[ip];
+                    o_temp = coeff
+                             * (diff * RPMean(value, pp[ip], 0.0, prod_der)
+                                - RPMean(value, pp[ip], prod_val, prod));
+                    break;
+                  }
+
+                case 1:
+                  {
+                    op = np;
+                    prod_val = rpp[ip + sy_v] * den_d;
+                    diff = pp[ip] - value;
+                    o_temp = -coeff
+                             * (diff * RPMean(pp[ip], value, prod_der, 0.0)
+                                + RPMean(pp[ip], value, prod, prod_val));
+                    break;
+                  }
+              }          /* End switch on fdir[1] */
+            }            /* End if (fdir[1]) */
+
+            else if (fdir[2])
+            {
+              coeff = dt * ffz * (2.0 / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]))) * permzp[ip] / viscosity;
+
+              switch (fdir[2])
+              {
+                case -1:
+                  {
+                    op = lp;
+                    prod_val = rpp[ip - sz_v] * den_d;
+
+                    lower_cond = (value) - 0.5 * dz * z_mult_dat[ip] * den_d * gravity;
+                    upper_cond = (pp[ip]) + 0.5 * dz * z_mult_dat[ip] * dp[ip] * gravity;
+                    diff = lower_cond - upper_cond;
+
+                    o_temp = coeff
+                             * (diff * RPMean(lower_cond, upper_cond, 0.0, prod_der)
+                                + ((-1.0 - gravity * 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip - sz_v]) * ddp[ip])
+                                   * RPMean(lower_cond, upper_cond, prod_val, prod)));
+                    break;
+                  }
+
+                case 1:
+                  {
+                    op = up;
+                    prod_val = rpp[ip + sz_v] * den_d;
+
+                    lower_cond = (pp[ip]) - 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * dp[ip] * gravity;
+                    upper_cond = (value) + 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * den_d * gravity;
+                    diff = lower_cond - upper_cond;
+
+                    o_temp = -coeff
+                             * (diff * RPMean(lower_cond, upper_cond, prod_der, 0.0)
+                                + ((1.0 - gravity * 0.5 * dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v]) * ddp[ip])
+                                   * RPMean(lower_cond, upper_cond, prod, prod_val)));
+                    break;
+                  }
+              }          /* End switch on fdir[2] */
+            }         /* End if (fdir[2]) */
+
+            cp[im] += op[im];
+            cp[im] -= o_temp;
+            op[im] = 0.0;
+          });
+
+          break;
+        }               /* End DirichletBC case */
+
+        case FluxBC:
+        {
+          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+          {
+            im = SubmatrixEltIndex(J_sub, i, j, k);
+
+            if (fdir[0] == -1)
+              op = wp;
+            if (fdir[0] == 1)
+              op = ep;
+            if (fdir[1] == -1)
+              op = sop;
+            if (fdir[1] == 1)
+              op = np;
+            if (fdir[2] == -1)
+              op = lp;
+            if (fdir[2] == 1)
+              op = up;
+
+            cp[im] += op[im];
+            op[im] = 0.0;
+          });
+
+          break;
+        }         /* End fluxbc case */
+
+        case OverlandBC:     //sk
+        {
+          BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+          {
+            im = SubmatrixEltIndex(J_sub, i, j, k);
+
+            //remove contributions to this row corresponding to boundary
+            if (fdir[0] == -1)
+              op = wp;
+            else if (fdir[0] == 1)
+              op = ep;
+            else if (fdir[1] == -1)
+              op = sop;
+            else if (fdir[1] == 1)
+              op = np;
+            else if (fdir[2] == -1)
+              op = lp;
+            else       // (fdir[2] ==  1)
+            {
+              op = up;
+              /* check if overland flow kicks in */
+              if (!ovlnd_flag)
+              {
+                ip = SubvectorEltIndex(p_sub, i, j, k);
+                if ((pp[ip]) > 0.0)
+                {
+                  ovlnd_flag = 1;
+                }
+              }
+            }
+
+            cp[im] += op[im];
+            op[im] = 0.0;       //zero out entry in row of Jacobian
+          });
+
+          switch (public_xtra->type)
+          {
+            case no_nonlinear_jacobian:
+            case not_set:
+            {
+              assert(1);
+            }
+
+            case simple:
+            {
+              BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+              {
+                if (fdir[2] == 1)
+                {
+                  ip = SubvectorEltIndex(p_sub, i, j, k);
+                  io = SubvectorEltIndex(p_sub, i, j, 0);
+                  im = SubmatrixEltIndex(J_sub, i, j, k);
+
+                  if ((pp[ip]) > 0.0)
+                  {
+                    cp[im] += (vol * z_mult_dat[ip]) / (dz * Mean(z_mult_dat[ip], z_mult_dat[ip + sz_v])) * (dt + 1);
+                  }
+                }
+              });
+              break;
+            }
+
+            case overland_flow:
+            {
+              /* Get overland flow contributions - DOK*/
+              // SGS can we skip this invocation if !overland_flow?
+              //PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module,
+              //		(grid, is, bc_struct, ipatch, problem_data, pressure,
+              //		 ke_der, kw_der, kn_der, ks_der, NULL, NULL, CALCDER));
+
+              if (overlandspinup == 1)
+              {
+                /* add flux loss equal to excess head  that overwrites the prior overland flux */
+                BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+                {
+                  if (fdir[2] == 1)
+                  {
+                    ip = SubvectorEltIndex(p_sub, i, j, k);
+                    io = SubvectorEltIndex(p_sub, i, j, 0);
+                    im = SubmatrixEltIndex(J_sub, i, j, k);
+                    vol = dx * dy * dz;
+
+                    if ((pp[ip]) >= 0.0)
+                    {
+                      cp[im] += (vol / dz) * dt * (1.0 + 0.0);                     //LEC
+                    }
+                    else
+                    {
+                      cp[im] += 0.0;
+                    }
+                  }
+                });
+              }
+              else
+              {
+                /* Get overland flow contributions for using kinematic or diffusive - LEC */
+                if (diffusive == 0)
+                {
+                  PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module,
+                                     (grid, is, bc_struct, ipatch, problem_data, pressure,
+                                      ke_der, kw_der, kn_der, ks_der, NULL, NULL, CALCDER));
+                }
+                else
+                {
+                  /* Test running Diffuisve calc FCN */
+                  //double *dummy1, *dummy2, *dummy3, *dummy4;
+                  //PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff, (grid, is, bc_struct, ipatch, problem_data, pressure,
+                  //                                             ke_der, kw_der, kn_der, ks_der,
+                  //       dummy1, dummy2, dummy3, dummy4,
+                  //                                                    NULL, NULL, CALCFCN));
+
+                  PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
+                                     (grid, is, bc_struct, ipatch, problem_data, pressure,
+                                      ke_der, kw_der, kn_der, ks_der,
+                                      kens_der, kwns_der, knns_der, ksns_der, NULL, NULL, CALCDER));
+                }
+              }
+
+
+              break;
+            }
+          }
+        }         /* End overland flow case */
+      }        /* End switch BCtype */
+    }          /* End ipatch loop */
   }            /* End subgrid loop */
 
   PFModuleInvokeType(RichardsBCInternalInvoke, bc_internal, (problem, problem_data, NULL, J, time,
@@ -1356,113 +1415,119 @@ void    RichardsJacobianEval(
 
       top_dat = SubvectorData(top_sub);
 
-      Do_Richards_BuildJCMatrix(i, j, k, ival, bc_struct, ipatch, is,
+      for (ipatch = 0; ipatch < BCStructNumPatches(bc_struct); ipatch++)
       {
-        ApplyBCPatch(OverlandBC,
-                     NO_PROLOGUE,
-                     NO_EPILOGUE,
-                     FACE(Front,
-                     {
-                       /* Loop over boundary patches to build JC matrix.
-                        */
-                       io = SubmatrixEltIndex(J_sub, i, j, iz);
-                       io1 = SubvectorEltIndex(sx_sub, i, j, 0);
-                       itop = SubvectorEltIndex(top_sub, i, j, 0);
+        switch (BCStructBCType(bc_struct, ipatch))
+        {
+          case OverlandBC:
+          {
+            BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, is,
+            {
+              if (fdir[2] == 1)
+              {
+                /* Loop over boundary patches to build JC matrix.
+                 */
+                io = SubmatrixEltIndex(J_sub, i, j, iz);
+                io1 = SubvectorEltIndex(sx_sub, i, j, 0);
+                itop = SubvectorEltIndex(top_sub, i, j, 0);
 
-                       /* Update JC */
-                       ip = SubvectorEltIndex(p_sub, i, j, k);
-                       im = SubmatrixEltIndex(J_sub, i, j, k);
+                /* Update JC */
+                ip = SubvectorEltIndex(p_sub, i, j, k);
+                im = SubmatrixEltIndex(J_sub, i, j, k);
 
-                       /* First put contributions from subsurface diagonal onto diagonal of JC */
-                       cp_c[io] = cp[im];
-                       cp[im] = 0.0;         // update JB
-                       /* Now check off-diagonal nodes to see if any surface-surface connections exist */
-                       /* West */
-                       k1 = (int)top_dat[itop - 1];
+                /* First put contributions from subsurface diagonal onto diagonal of JC */
+                cp_c[io] = cp[im];
+                cp[im] = 0.0;         // update JB
+                /* Now check off-diagonal nodes to see if any surface-surface connections exist */
+                /* West */
+                k1 = (int)top_dat[itop - 1];
 
-                       if (k1 >= 0)
-                       {
-                         if (k1 == k)         /*west node is also surface node */
-                         {
-                           wp_c[io] += wp[im];
-                           wp[im] = 0.0;           // update JB
-                         }
-                       }
-                       /* East */
-                       k1 = (int)top_dat[itop + 1];
-                       if (k1 >= 0)
-                       {
-                         if (k1 == k)         /*east node is also surface node */
-                         {
-                           ep_c[io] += ep[im];
-                           ep[im] = 0.0;           //update JB
-                         }
-                       }
-                       /* South */
-                       k1 = (int)top_dat[itop - sy_v];
-                       if (k1 >= 0)
-                       {
-                         if (k1 == k)         /*south node is also surface node */
-                         {
-                           sop_c[io] += sop[im];
-                           sop[im] = 0.0;           //update JB
-                         }
-                       }
-                       /* North */
-                       k1 = (int)top_dat[itop + sy_v];
-                       if (k1 >= 0)
-                       {
-                         if (k1 == k)         /*north node is also surface node */
-                         {
-                           np_c[io] += np[im];
-                           np[im] = 0.0;           // Update JB
-                         }
-                       }
+                if (k1 >= 0)
+                {
+                  if (k1 == k)         /*west node is also surface node */
+                  {
+                    wp_c[io] += wp[im];
+                    wp[im] = 0.0;           // update JB
+                  }
+                }
+                /* East */
+                k1 = (int)top_dat[itop + 1];
+                if (k1 >= 0)
+                {
+                  if (k1 == k)         /*east node is also surface node */
+                  {
+                    ep_c[io] += ep[im];
+                    ep[im] = 0.0;           //update JB
+                  }
+                }
+                /* South */
+                k1 = (int)top_dat[itop - sy_v];
+                if (k1 >= 0)
+                {
+                  if (k1 == k)         /*south node is also surface node */
+                  {
+                    sop_c[io] += sop[im];
+                    sop[im] = 0.0;           //update JB
+                  }
+                }
+                /* North */
+                k1 = (int)top_dat[itop + sy_v];
+                if (k1 >= 0)
+                {
+                  if (k1 == k)         /*north node is also surface node */
+                  {
+                    np_c[io] += np[im];
+                    np[im] = 0.0;           // Update JB
+                  }
+                }
 
-                       /* Now add overland contributions to JC */
-                       if ((pp[ip]) > 0.0)
-                       {
-                         /*diagonal term */
-                         cp_c[io] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
-                                     + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
-                       }
-                       else
-                       {
-                         // Laura's version
-                         cp_c[io] += 0.0 + dt * (vol / dz) * (public_xtra->SpinupDampP1 * exp(pfmin(pp[ip], 0.0) * public_xtra->SpinupDampP1) * public_xtra->SpinupDampP2); //NBE
-                       }
+                /* Now add overland contributions to JC */
+                if ((pp[ip]) > 0.0)
+                {
+                  /*diagonal term */
+                  cp_c[io] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
+                              + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+                }
+                else
+                {
+                  // Laura's version
+                  cp_c[io] += 0.0 + dt * (vol / dz) * (public_xtra->SpinupDampP1 * exp(pfmin(pp[ip], 0.0) * public_xtra->SpinupDampP1) * public_xtra->SpinupDampP2); //NBE
+                }
 
-                       if (diffusive == 0)
-                       {
-                         /*west term */
-                         wp_c[io] -= (vol / ffy) * dt * (ke_der[io1 - 1]);
+                if (diffusive == 0)
+                {
+                  /*west term */
+                  wp_c[io] -= (vol / ffy) * dt * (ke_der[io1 - 1]);
 
-                         /*East term */
-                         ep_c[io] += (vol / ffy) * dt * (kw_der[io1 + 1]);
+                  /*East term */
+                  ep_c[io] += (vol / ffy) * dt * (kw_der[io1 + 1]);
 
-                         /*south term */
-                         sop_c[io] -= (vol / ffx) * dt * (kn_der[io1 - sy_v]);
+                  /*south term */
+                  sop_c[io] -= (vol / ffx) * dt * (kn_der[io1 - sy_v]);
 
-                         /*north term */
-                         np_c[io] += (vol / ffx) * dt * (ks_der[io1 + sy_v]);
-                       }
-                       else
-                       {
-                         /*west term */
-                         wp_c[io] -= (vol / ffy) * dt * (kwns_der[io1]);
+                  /*north term */
+                  np_c[io] += (vol / ffx) * dt * (ks_der[io1 + sy_v]);
+                }
+                else
+                {
+                  /*west term */
+                  wp_c[io] -= (vol / ffy) * dt * (kwns_der[io1]);
 
-                         /*East term */
-                         ep_c[io] += (vol / ffy) * dt * (kens_der[io1]);
+                  /*East term */
+                  ep_c[io] += (vol / ffy) * dt * (kens_der[io1]);
 
-                         /*south term */
-                         sop_c[io] -= (vol / ffx) * dt * (ksns_der[io1]);
+                  /*south term */
+                  sop_c[io] -= (vol / ffx) * dt * (ksns_der[io1]);
 
-                         /*north term */
-                         np_c[io] += (vol / ffx) * dt * (knns_der[io1]);
-                       }
-                     })
-                     ); // End OverlandBC
-      }); // End Do_Richards_BuildJCMatrix
+                  /*north term */
+                  np_c[io] += (vol / ffx) * dt * (knns_der[io1]);
+                }
+              }
+            });
+            break;
+          }
+        }         /* End switch BCtype */
+      }           /* End ipatch loop */
     }             /* End subgrid loop */
   }
 


### PR DESCRIPTION
In progress to #9 #14 #15 

Note: Primary work and changes live in `bc_faces.h` and in `richards_jacobian_eval.c`, rest of macros are setting up loop changes to work with this system.

Current progress:
- [X] Set up `ForBCStructNumPatches` macro
- [X] Design a macro system for applying BC contributions (`ApplyBCPatch`)
- [X] Set up `BCStructPatchLoopX`,  `GrGeomPatchLoopX`, and `GrGeomOctreeFaceLoopX`  macro to handle `ApplyBCPatch` macro
- [X] Convert RichardsJacobian Symmetric contribution loop to use new macro system
- [X] Convert RichardsJacobian Boundary Condition Contribution loops to use new macro system
- [X] Convert RichardsJacobian JC Submatrix loop to use new macro system
- [X] #14 DirichletBC Pressure macro written, needs to be removed from this PR and into its own
- [?] #15 Apply macro system to `NlFunctionEval`
  - Precondition / Postcondition macros
- [ ] Compiles correctly
- [ ] Document system
- [ ] Decide how to handle outer iteration spaces, specify them directly or use `Do_` macro verbage?
- [ ] Decide on specific naming schemes
- [ ] Decide on specific header file organization
- [ ] Determine which macro systems can be used in both Richards and NL (i.e. where can we remove "Richards" from the `Do_*` macros and also use them in `NlFunctionEval`)
- [ ] Verify output
- [ ] Check performance changes (in serial)